### PR TITLE
Fix unwanted removal of bank tab separator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 
-def runeLiteVersion = '1.7.22'
+def runeLiteVersion = '1.7.24'
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
 

--- a/src/main/java/inventorysetups/InventorySetupsPlugin.java
+++ b/src/main/java/inventorysetups/InventorySetupsPlugin.java
@@ -1012,7 +1012,7 @@ public class InventorySetupsPlugin extends Plugin
 			return;
 		}
 
-		if (panel.getCurrentSelectedSetup() != null && config.removeBankTabSeparator())
+		if (panel.getCurrentSelectedSetup() != null && config.removeBankTabSeparator() && isFilteringAllowed())
 		{
 			Widget[] containerChildren = itemContainer.getDynamicChildren();
 


### PR DESCRIPTION
The new option to remove the bank tab separator is also applying when you're not filtering the bank and just trying to view the main all items tab. This small tweak fixes that.