### PR TITLE
add ability to configure the color of setup names

### DIFF
--- a/src/main/java/inventorysetups/InventorySetup.java
+++ b/src/main/java/inventorysetups/InventorySetup.java
@@ -67,6 +67,10 @@ public class InventorySetup
 
 	@Getter
 	@Setter
+	private Color displayColor;
+
+	@Getter
+	@Setter
 	private boolean filterBank;
 
 	@Getter

--- a/src/main/java/inventorysetups/InventorySetupsConfig.java
+++ b/src/main/java/inventorysetups/InventorySetupsConfig.java
@@ -153,7 +153,7 @@ public interface InventorySetupsConfig extends Config
 	)
 	default Color displayColor()
 	{
-		return JagexColors.MENU_TARGET;
+		return null;
 	}
 
 	@ConfigItem(

--- a/src/main/java/inventorysetups/InventorySetupsConfig.java
+++ b/src/main/java/inventorysetups/InventorySetupsConfig.java
@@ -31,6 +31,7 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.ConfigSection;
 import net.runelite.client.config.Keybind;
+import net.runelite.client.ui.JagexColors;
 
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_COMPACT_MODE;
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_HIDE_BUTTON;
@@ -144,10 +145,22 @@ public interface InventorySetupsConfig extends Config
 	}
 
 	@ConfigItem(
+			keyName = "displayColor",
+			name = "Default Display Color",
+			description = "Configures the default display color in new setups",
+			position = 6,
+			section = defaultSection
+	)
+	default Color displayColor()
+	{
+		return JagexColors.MENU_TARGET;
+	}
+
+	@ConfigItem(
 			keyName = "fuzzy",
 			name = "Default Fuzzy",
 			description = "Configures the default setting for fuzziness in new setups",
-			position = 6,
+			position = 7,
 			section = defaultSection
 	)
 	default boolean fuzzy()
@@ -159,7 +172,7 @@ public interface InventorySetupsConfig extends Config
 			keyName = "stackCompare",
 			name = "Default Stack Compare",
 			description = "Configures the default setting for stack compare in new setups",
-			position = 7,
+			position = 8,
 			section = defaultSection
 	)
 	default InventorySetupsStackCompareID stackCompareType()

--- a/src/main/java/inventorysetups/InventorySetupsPlugin.java
+++ b/src/main/java/inventorysetups/InventorySetupsPlugin.java
@@ -32,6 +32,7 @@ import com.google.gson.reflect.TypeToken;
 import com.google.inject.Provides;
 import inventorysetups.ui.InventorySetupsPluginPanel;
 import inventorysetups.ui.InventorySetupsSlot;
+import java.awt.Color;
 import java.awt.Toolkit;
 import java.awt.datatransfer.StringSelection;
 import java.awt.image.BufferedImage;
@@ -383,9 +384,10 @@ public class InventorySetupsPlugin extends Plugin
 			for (int i = 0; i < setupsToShowOnWornItemsList.size(); i++)
 			{
 				final ShowWornItemsPair setupIndexPair = setupsToShowOnWornItemsList.get(setupsToShowOnWornItemsList.size() - 1 - i);
+				Color menuTargetColor = setupIndexPair.setup.getDisplayColor() == null ? JagexColors.MENU_TARGET : setupIndexPair.setup.getDisplayColor();
 				client.createMenuEntry(-1)
 						.setOption(OPEN_SETUP_MENU_ENTRY)
-						.setTarget(ColorUtil.prependColorTag(setupIndexPair.setup.getName(), setupIndexPair.setup.getDisplayColor()))
+						.setTarget(ColorUtil.prependColorTag(setupIndexPair.setup.getName(), menuTargetColor))
 						.setIdentifier(setupIndexPair.index) // The param will used to find the correct setup if a menu entry is clicked
 						.setType(MenuAction.RUNELITE)
 						.onClick(e ->
@@ -2040,10 +2042,6 @@ public class InventorySetupsPlugin extends Plugin
 			if (setup.getAdditionalFilteredItems() == null)
 			{
 				setup.updateAdditionalItems(new HashMap<>());
-			}
-			if (setup.getDisplayColor() == null)
-			{
-				setup.setDisplayColor(config.displayColor());
 			}
 		}
 

--- a/src/main/java/inventorysetups/InventorySetupsPlugin.java
+++ b/src/main/java/inventorysetups/InventorySetupsPlugin.java
@@ -385,7 +385,7 @@ public class InventorySetupsPlugin extends Plugin
 				final ShowWornItemsPair setupIndexPair = setupsToShowOnWornItemsList.get(setupsToShowOnWornItemsList.size() - 1 - i);
 				client.createMenuEntry(-1)
 						.setOption(OPEN_SETUP_MENU_ENTRY)
-						.setTarget(ColorUtil.prependColorTag(setupIndexPair.setup.getName(), JagexColors.MENU_TARGET))
+						.setTarget(ColorUtil.prependColorTag(setupIndexPair.setup.getName(), setupIndexPair.setup.getDisplayColor()))
 						.setIdentifier(setupIndexPair.index) // The param will used to find the correct setup if a menu entry is clicked
 						.setType(MenuAction.RUNELITE)
 						.onClick(e ->
@@ -642,6 +642,7 @@ public class InventorySetupsPlugin extends Plugin
 			final InventorySetup invSetup = new InventorySetup(inv, eqp, runePouchData, boltPouchData, new HashMap<>(), name, "",
 				config.highlightColor(),
 				config.highlightDifference(),
+				config.displayColor(),
 				config.bankFilter(),
 				config.highlightUnorderedDifference(),
 				spellbook, nextInventorySetupId, false);
@@ -2039,6 +2040,10 @@ public class InventorySetupsPlugin extends Plugin
 			if (setup.getAdditionalFilteredItems() == null)
 			{
 				setup.updateAdditionalItems(new HashMap<>());
+			}
+			if (setup.getDisplayColor() == null)
+			{
+				setup.setDisplayColor(config.displayColor());
 			}
 		}
 

--- a/src/main/java/inventorysetups/ui/InventorySetupsCompactPanel.java
+++ b/src/main/java/inventorysetups/ui/InventorySetupsCompactPanel.java
@@ -32,6 +32,7 @@ import net.runelite.client.ui.components.FlatTextField;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
+import javax.swing.border.MatteBorder;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -56,7 +57,7 @@ public class InventorySetupsCompactPanel extends InventorySetupsPanel
 
 		final FlatTextField nameInput = new FlatTextField();
 		nameInput.setText(inventorySetup.getName());
-		nameInput.setBorder(null);
+		nameInput.setBorder(new MatteBorder(0, 2, 0, 0, invSetup.getDisplayColor()));
 		nameInput.setEditable(false);
 		nameInput.setBackground(ColorScheme.DARKER_GRAY_COLOR);
 		nameInput.setPreferredSize(new Dimension(0, 24));

--- a/src/main/java/inventorysetups/ui/InventorySetupsStandardPanel.java
+++ b/src/main/java/inventorysetups/ui/InventorySetupsStandardPanel.java
@@ -29,6 +29,7 @@ import inventorysetups.InventorySetupsPlugin;
 
 import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
+import net.runelite.client.ui.JagexColors;
 import net.runelite.client.ui.components.FlatTextField;
 import net.runelite.client.ui.components.colorpicker.RuneliteColorPicker;
 import net.runelite.client.util.ImageUtil;
@@ -184,7 +185,20 @@ public class InventorySetupsStandardPanel extends InventorySetupsPanel
 
 		JPanel nameWrapper = new JPanel(new BorderLayout());
 		nameWrapper.setBackground(ColorScheme.DARKER_GRAY_COLOR);
-		nameWrapper.setBorder(NAME_BOTTOM_BORDER);
+
+		Color currentDisplayColor;
+		if (invSetup.getDisplayColor() == null)
+		{
+			nameWrapper.setBorder(NAME_BOTTOM_BORDER);
+			currentDisplayColor = JagexColors.MENU_TARGET;;
+		}
+		else
+		{
+			nameWrapper.setBorder(new CompoundBorder(
+					BorderFactory.createMatteBorder(0, 0, 2, 0, invSetup.getDisplayColor()),
+					BorderFactory.createLineBorder(ColorScheme.DARKER_GRAY_COLOR)));
+			currentDisplayColor = invSetup.getDisplayColor();
+		}
 
 		JPanel nameActions = new JPanel(new BorderLayout(3, 0));
 		nameActions.setBorder(new EmptyBorder(0, 0, 0, 8));
@@ -202,6 +216,10 @@ public class InventorySetupsStandardPanel extends InventorySetupsPanel
 				{
 					inventorySetup.setName(nameInput.getText());
 					Color newDisplayColor = ((MatteBorder)((CompoundBorder) displayColorIndicator.getBorder()).getInsideBorder()).getMatteColor();
+					if (newDisplayColor == JagexColors.MENU_TARGET)
+					{
+						newDisplayColor = null;
+					}
 					inventorySetup.setDisplayColor(newDisplayColor);
 
 					plugin.updateConfig();
@@ -240,7 +258,7 @@ public class InventorySetupsStandardPanel extends InventorySetupsPanel
 					nameInput.setText(inventorySetup.getName());
 					updateNameActions(false);
 					requestFocusInWindow();
-					updateDisplayColorLabel();
+					updateDisplayColorLabel(currentDisplayColor);
 				}
 			}
 
@@ -300,7 +318,7 @@ public class InventorySetupsStandardPanel extends InventorySetupsPanel
 		displayColorIndicator.setToolTipText("Edit the color of the name");
 		displayColorIndicator.setIcon(DISPLAY_COLOR_ICON);
 		displayColorIndicator.setVisible(false);
-		updateDisplayColorLabel();
+		updateDisplayColorLabel(currentDisplayColor);
 		displayColorIndicator.addMouseListener(new MouseAdapter()
 		{
 			@Override
@@ -308,12 +326,10 @@ public class InventorySetupsStandardPanel extends InventorySetupsPanel
 			{
 				if (SwingUtilities.isLeftMouseButton(mouseEvent))
 				{
-					openColorPicker("Choose a Display color", invSetup.getDisplayColor(),
+					openColorPicker("Choose a Display color", currentDisplayColor,
 						c ->
 						{
-							displayColorIndicator.setBorder(new CompoundBorder(
-									new EmptyBorder(0, 4, 0, 0),
-									new MatteBorder(0, 0, 3, 0, c)));
+							updateDisplayColorLabel(c);
 						}
 					);
 				}
@@ -618,9 +634,8 @@ public class InventorySetupsStandardPanel extends InventorySetupsPanel
 		highlightColorIndicator.setIcon(inventorySetup.isHighlightDifference() ? HIGHLIGHT_COLOR_ICON : NO_HIGHLIGHT_COLOR_ICON);
 	}
 
-	private void updateDisplayColorLabel()
+	private void updateDisplayColorLabel(Color color)
 	{
-		Color color = inventorySetup.getDisplayColor();
 		displayColorIndicator.setBorder(new CompoundBorder(
 				new EmptyBorder(0, 4, 0, 0),
 				new MatteBorder(0, 0, 3, 0, color)));

--- a/src/main/java/inventorysetups/ui/InventorySetupsStandardPanel.java
+++ b/src/main/java/inventorysetups/ui/InventorySetupsStandardPanel.java
@@ -96,6 +96,9 @@ public class InventorySetupsStandardPanel extends InventorySetupsPanel
 	private static final ImageIcon EXPORT_ICON;
 	private static final ImageIcon EXPORT_HOVER_ICON;
 
+	private static final ImageIcon DISPLAY_COLOR_ICON;
+	private static final ImageIcon DISPLAY_COLOR_HOVER_ICON;
+
 	private final JLabel bankFilterIndicator = new JLabel();
 	private final JLabel highlightColorIndicator = new JLabel();
 	private final JLabel unorderedHighlightIndicator = new JLabel();
@@ -104,6 +107,7 @@ public class InventorySetupsStandardPanel extends InventorySetupsPanel
 	private final JLabel viewSetupLabel = new JLabel();
 	private final JLabel exportLabel = new JLabel();
 	private final JLabel deleteLabel = new JLabel();
+	private final JLabel displayColorIndicator = new JLabel();
 
 	private final FlatTextField nameInput = new FlatTextField();
 	private final JLabel save = new JLabel("Save");
@@ -165,6 +169,9 @@ public class InventorySetupsStandardPanel extends InventorySetupsPanel
 		final BufferedImage deleteImg = ImageUtil.loadImageResource(InventorySetupsPlugin.class, "/delete_icon.png");
 		DELETE_ICON = new ImageIcon(deleteImg);
 		DELETE_HOVER_ICON = new ImageIcon(ImageUtil.luminanceOffset(deleteImg, -100));
+
+		DISPLAY_COLOR_ICON = new ImageIcon(highlightImg);
+		DISPLAY_COLOR_HOVER_ICON = new ImageIcon(highlightHover);
 	}
 
 	InventorySetupsStandardPanel(InventorySetupsPlugin plugin, InventorySetupsPluginPanel panel, InventorySetup invSetup)
@@ -285,8 +292,36 @@ public class InventorySetupsStandardPanel extends InventorySetupsPanel
 		nameInput.getTextField().setBorder(new EmptyBorder(0, 8, 0, 0));
 		nameInput.getTextField().setComponentPopupMenu(moveSetupPopupMenu);
 
+		displayColorIndicator.setToolTipText("Edit the color of the name");
+		displayColorIndicator.setIcon(DISPLAY_COLOR_ICON);
+		displayColorIndicator.setBorder(new MatteBorder(0, 0, 3, 0, invSetup.getDisplayColor()));
+		displayColorIndicator.addMouseListener(new MouseAdapter()
+		{
+			@Override
+			public void mousePressed(MouseEvent mouseEvent)
+			{
+				if (SwingUtilities.isLeftMouseButton(mouseEvent))
+				{
+					openDisplayColorPicker();
+				}
+			}
+
+			@Override
+			public void mouseEntered(MouseEvent mouseEvent)
+			{
+				displayColorIndicator.setIcon(DISPLAY_COLOR_HOVER_ICON);
+			}
+
+			@Override
+			public void mouseExited(MouseEvent mouseEvent)
+			{
+				displayColorIndicator.setIcon(DISPLAY_COLOR_ICON);
+			}
+		});
+
 		nameWrapper.add(nameInput, BorderLayout.CENTER);
 		nameWrapper.add(nameActions, BorderLayout.EAST);
+		nameWrapper.add(displayColorIndicator, BorderLayout.WEST);
 
 		JPanel bottomContainer = new JPanel(new BorderLayout());
 		bottomContainer.setBorder(new EmptyBorder(8, 0, 8, 0));
@@ -563,6 +598,13 @@ public class InventorySetupsStandardPanel extends InventorySetupsPanel
 		highlightColorIndicator.setIcon(inventorySetup.isHighlightDifference() ? HIGHLIGHT_COLOR_ICON : NO_HIGHLIGHT_COLOR_ICON);
 	}
 
+	private void updateDisplayColorLabel()
+	{
+		Color color = inventorySetup.getDisplayColor();
+		displayColorIndicator.setBorder(new MatteBorder(0, 0, 3, 0, color));
+		displayColorIndicator.setIcon(DISPLAY_COLOR_ICON);
+	}
+
 	private void updateBankFilterLabel()
 	{
 		bankFilterIndicator.setIcon(inventorySetup.isFilterBank() ? BANK_FILTER_ICON : NO_BANK_FILTER_ICON);
@@ -597,6 +639,34 @@ public class InventorySetupsStandardPanel extends InventorySetupsPanel
 		{
 			inventorySetup.setHighlightColor(c);
 			updateHighlightColorLabel();
+		});
+
+		colorPicker.addWindowListener(new WindowAdapter()
+		{
+			@Override
+			public void windowClosing(WindowEvent e)
+			{
+				plugin.updateConfig();
+			}
+		});
+
+		colorPicker.setVisible(true);
+	}
+
+	private void openDisplayColorPicker()
+	{
+
+		RuneliteColorPicker colorPicker = plugin.getColorPickerManager().create(
+				SwingUtilities.windowForComponent(this),
+				inventorySetup.getDisplayColor(),
+				inventorySetup.getName(),
+				false);
+
+		colorPicker.setLocation(getLocationOnScreen());
+		colorPicker.setOnColorChange(c ->
+		{
+			inventorySetup.setDisplayColor(c);
+			updateDisplayColorLabel();
 		});
 
 		colorPicker.addWindowListener(new WindowAdapter()

--- a/src/test/java/inventorysetups/InventorySetupsUnitTest.java
+++ b/src/test/java/inventorysetups/InventorySetupsUnitTest.java
@@ -95,7 +95,7 @@ public class InventorySetupsUnitTest
 		Map<Integer, InventorySetupsItem> addItems = new HashMap<>();
 		InventorySetup setup = new InventorySetup(inventory, equipment, runePouch, boltPouch, addItems, "Test",
 												"", inventorySetupsConfig.highlightColor(), false,
-										false,false, 0, 0L, false);
+												inventorySetupsConfig.displayColor(), false,false, 0, 0L, false);
 
 		assertFalse(inventorySetupsPlugin.setupContainsItem(setup, ItemID.COAL));
 	}


### PR DESCRIPTION
Close #123

Hey, I added the ability to configure the color of setup names. Really not sure how this should look from a UI perspective and would love some input. Currently, the label is placed next to the name on the StandardPanel and uses the highlight color icon as a placeholder.

![image](https://user-images.githubusercontent.com/85463994/162193897-34785faa-c533-4f2c-b7c6-3994f151a051.png) ![image](https://user-images.githubusercontent.com/85463994/162194479-99ebace4-d6f0-4f88-8e95-5e7ca998217f.png)

Also, I wasn't sure if the color should be used in the nameInput label in the StandardPanel or the title in the PluginPanel.