### PR TITLE
Fix build failure due to API changes in Runelite 1.8.25.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ repositories {
 }
 
 
-def runeLiteVersion = '1.8.23'
+def runeLiteVersion = '1.8.25'
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion
 

--- a/src/main/java/inventorysetups/InventorySetupsBankSearch.java
+++ b/src/main/java/inventorysetups/InventorySetupsBankSearch.java
@@ -110,8 +110,8 @@ public class InventorySetupsBankSearch
 			}
 			else
 			{
-				client.setVar(VarClientInt.INPUT_TYPE, InputType.NONE.getType());
-				client.setVar(VarClientStr.INPUT_TEXT, "");
+				client.setVarcIntValue(VarClientInt.INPUT_TYPE, InputType.NONE.getType());
+				client.setVarcStrValue(VarClientStr.INPUT_TEXT, "");
 			}
 
 			layoutBank();


### PR DESCRIPTION
Close #140

Runelite 1.8.25 renames Client.setVar overloads() to Client.setVarcIntValue() and set Client.setVarcStrValue().
This change updates the plugin's usage of these functions accordingly.