### PR TITLE
Search for inventory setup via setup name or contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ You can go back to the overview panel by clicking on the back arrow in the top r
 ![Return to Overview Panel](readme_images_and_gifs/return_to_setups_button.png)
 
 You can also search for setups using the search bar. When typing in the search bar, setups will be filtered if they contain the search text.
+By default, the search criteria will filter the setups by their names. If you want to search for setups containing specific items, prefix
+your search with `item:`, e.g. `item:brew`.
 
 ![Search Bar](readme_images_and_gifs/search_bar.gif)
 

--- a/src/main/java/inventorysetups/InventorySetupsPlugin.java
+++ b/src/main/java/inventorysetups/InventorySetupsPlugin.java
@@ -41,14 +41,7 @@ import java.lang.reflect.Type;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 import javax.inject.Inject;
@@ -1036,10 +1029,29 @@ public class InventorySetupsPlugin extends Plugin
 
 	public List<InventorySetup> filterSetups(String textToFilter)
 	{
-		final String textToFilterLower = textToFilter.toLowerCase();
-		return inventorySetups.stream()
-			.filter(i -> i.getName().toLowerCase().contains(textToFilterLower))
-			.collect(Collectors.toList());
+    return inventorySetups.stream().filter(i -> setupContains(i, textToFilter.toLowerCase())).collect(Collectors.toList());
+	}
+
+	private static boolean setupContains(InventorySetup i, String textToFilterLower)
+	{
+		if (textToFilterLower.startsWith("item:") && textToFilterLower.length() >= 6)
+		{
+			String itemName = textToFilterLower.substring("item:".length());
+			// Find setups containing the given item name
+			return containsItem(i.getInventory(), itemName) || containsItem(i.getEquipment(), itemName)
+					|| containsItem(i.getBoltPouch(), itemName) || containsItem(i.getRune_pouch(), itemName);
+		}
+		// Find setups containing the given setup name (default behaviour)
+		return i.getName().toLowerCase().contains(textToFilterLower);
+	}
+
+	private static boolean containsItem(List<InventorySetupsItem> inventorySetupItems, String textToFilterLower) {
+		if (inventorySetupItems == null) {
+			return false;
+		}
+		return inventorySetupItems.stream().filter(Objects::nonNull)
+        .map(item -> item.getName().toLowerCase())
+        .anyMatch(itemName -> itemName.contains(textToFilterLower));
 	}
 
 	public void doBankSearch(final InventorySetupsFilteringModeID filteringModeID)
@@ -2446,7 +2458,7 @@ public class InventorySetupsPlugin extends Plugin
 		}
 		else if (runePouchTypeOldItem != InventorySetupsRunePouchType.NONE)
 		{
-			// if the old item is a rune pouch, need to update it to null 
+			// if the old item is a rune pouch, need to update it to null
 			inventorySetup.updateRunePouch(null);
 		}
 

--- a/src/main/java/inventorysetups/InventorySetupsPlugin.java
+++ b/src/main/java/inventorysetups/InventorySetupsPlugin.java
@@ -1039,22 +1039,22 @@ public class InventorySetupsPlugin extends Plugin
 	public List<InventorySetup> filterSetups(String textToFilter)
 	{
 		return inventorySetups.stream()
-			.filter(inventorySetup -> setupContains(inventorySetup, textToFilter.toLowerCase()))
+			.filter(inventorySetup -> shouldDisplaySetup(inventorySetup, textToFilter.trim().toLowerCase()))
 			.collect(Collectors.toList());
 	}
 
-	private static boolean setupContains(InventorySetup inventorySetup, String textToFilterLower)
+	private static boolean shouldDisplaySetup(InventorySetup inventorySetup, String trimmedTextToFilterLower)
 	{
-		if (textToFilterLower.startsWith(ITEM_SEARCH_TAG) && textToFilterLower.length() > ITEM_SEARCH_TAG.length())
+		if (trimmedTextToFilterLower.startsWith(ITEM_SEARCH_TAG) && trimmedTextToFilterLower.length() > ITEM_SEARCH_TAG.length())
 		{
-			String itemName = textToFilterLower.trim().substring(ITEM_SEARCH_TAG.length());
+			String itemName = trimmedTextToFilterLower.substring(ITEM_SEARCH_TAG.length()).trim();
 			// Find setups containing the given item name
 			return containerContainsItemByName(inventorySetup.getInventory(), itemName) || containerContainsItemByName(inventorySetup.getEquipment(), itemName)
 				|| containerContainsItemByName(inventorySetup.getBoltPouch(), itemName) || containerContainsItemByName(inventorySetup.getRune_pouch(), itemName)
 				|| containerContainsItemByName(inventorySetup.getAdditionalFilteredItems().values(), itemName);
 		}
 		// Find setups containing the given setup name (default behaviour)
-		return inventorySetup.getName().toLowerCase().contains(textToFilterLower);
+		return inventorySetup.getName().toLowerCase().contains(trimmedTextToFilterLower);
 	}
 
 	private static boolean containerContainsItemByName(Collection<InventorySetupsItem> itemsInContainer, String textToFilterLower)

--- a/src/main/java/inventorysetups/InventorySetupsPlugin.java
+++ b/src/main/java/inventorysetups/InventorySetupsPlugin.java
@@ -1050,8 +1050,8 @@ public class InventorySetupsPlugin extends Plugin
 			String itemName = trimmedTextToFilterLower.substring(ITEM_SEARCH_TAG.length()).trim();
 			// Find setups containing the given item name
 			return containerContainsItemByName(inventorySetup.getInventory(), itemName) || containerContainsItemByName(inventorySetup.getEquipment(), itemName)
-				|| containerContainsItemByName(inventorySetup.getBoltPouch(), itemName) || containerContainsItemByName(inventorySetup.getRune_pouch(), itemName)
-				|| containerContainsItemByName(inventorySetup.getAdditionalFilteredItems().values(), itemName);
+				|| containerContainsItemByName(inventorySetup.getRune_pouch(), itemName) || containerContainsItemByName(inventorySetup.getAdditionalFilteredItems().values(), itemName)
+				|| containerContainsItemByName(inventorySetup.getBoltPouch(), itemName);
 		}
 		// Find setups containing the given setup name (default behaviour)
 		return inventorySetup.getName().toLowerCase().contains(trimmedTextToFilterLower);

--- a/src/main/java/inventorysetups/ui/InventorySetupsPluginPanel.java
+++ b/src/main/java/inventorysetups/ui/InventorySetupsPluginPanel.java
@@ -437,7 +437,7 @@ public class InventorySetupsPluginPanel extends PluginPanel
 			{
 				if (SwingUtilities.isLeftMouseButton(e))
 				{
-					returnToOverviewPanel(false);
+					redrawOverviewPanel(false);
 				}
 			}
 
@@ -631,7 +631,6 @@ public class InventorySetupsPluginPanel extends PluginPanel
 	// Redraw the entire overview panel, considering the text in the search bar
 	public void redrawOverviewPanel(boolean resetScrollBar)
 	{
-		returnToOverviewPanel(resetScrollBar);
 		InventorySetupUtilities.fastRemoveAll(overviewPanel);
 		updateSectionViewMarker();
 		updatePanelViewMarker();
@@ -653,6 +652,7 @@ public class InventorySetupsPluginPanel extends PluginPanel
 			filteredInventorysetups.sort(Comparator.comparing(InventorySetup::getName, String.CASE_INSENSITIVE_ORDER));
 		}
 
+		returnToOverviewPanel(resetScrollBar);
 		layoutSetups(filteredInventorysetups);
 
 		revalidate();


### PR DESCRIPTION
As discussed in #235, search using the "item:" prefix to search for specific inventory/equipment/bolt pouch/rune pouch items by name.

![image](https://github.com/dillydill123/inventory-setups/assets/31489752/f2016f94-de11-43d6-83eb-923f4582a355)
