### PR TITLE
Add config option to remember last active inventory-setup,

### DIFF
--- a/src/main/java/inventorysetups/InventorySetupsConfig.java
+++ b/src/main/java/inventorysetups/InventorySetupsConfig.java
@@ -26,6 +26,7 @@ package inventorysetups;
 
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_HIDE_BUTTON;
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_MANUAL_BANK_FILTER;
+import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_REMEMBER_LAST_SETUP;
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_PANEL_VIEW;
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_PERSIST_HOTKEYS;
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_SECTION_MODE;
@@ -452,6 +453,17 @@ public interface InventorySetupsConfig extends Config
 			position = 27
 	)
 	default boolean manualBankFilter()
+	{
+		return false;
+	}
+
+	@ConfigItem(
+			keyName = CONFIG_KEY_REMEMBER_LAST_SETUP,
+			name = "Remember Last Setup",
+			description = "If a setup was active previously, it will be opened when the client or plugin starts",
+			position = 28
+	)
+	default boolean rememberLastSetup()
 	{
 		return false;
 	}

--- a/src/main/java/inventorysetups/InventorySetupsPlugin.java
+++ b/src/main/java/inventorysetups/InventorySetupsPlugin.java
@@ -136,6 +136,8 @@ public class InventorySetupsPlugin extends Plugin
 	public static final String CONFIG_KEY_VERSION_STR = "version";
 	public static final String CONFIG_KEY_UNASSIGNED_MAXIMIZED = "unassignedMaximized";
 	public static final String CONFIG_KEY_MANUAL_BANK_FILTER = "manualBankFilter";
+	public static final String CONFIG_KEY_REMEMBER_LAST_SETUP = "rememberLastSetup";
+	public static final String CONFIG_KEY_LAST_SETUP_VALUE = "lastSetupValue";
 	public static final String CONFIG_KEY_PERSIST_HOTKEYS = "persistHotKeysOutsideBank";
 	public static final String TUTORIAL_LINK = "https://github.com/dillydill123/inventory-setups#inventory-setups";
 	public static final String SUGGESTION_LINK = "https://github.com/dillydill123/inventory-setups/issues";
@@ -863,7 +865,22 @@ public class InventorySetupsPlugin extends Plugin
 			clientThread.invokeLater(() ->
 			{
 				dataManager.loadConfig();
-				SwingUtilities.invokeLater(() -> panel.redrawOverviewPanel(true));
+				SwingUtilities.invokeLater(() ->
+				{
+					panel.redrawOverviewPanel(true);
+					if (config.rememberLastSetup())
+					{
+						String lastSetupName = configManager.getConfiguration(CONFIG_GROUP, CONFIG_KEY_LAST_SETUP_VALUE);
+						if (!lastSetupName.isEmpty())
+						{
+							final InventorySetup lastSetup = getCache().getInventorySetupNames().get(lastSetupName);
+							if (lastSetup != null)
+							{
+								panel.setCurrentInventorySetup(lastSetup, true);
+							}
+						}
+					}
+				});
 			});
 
 			return true;

--- a/src/main/java/inventorysetups/ui/InventorySetupsPluginPanel.java
+++ b/src/main/java/inventorysetups/ui/InventorySetupsPluginPanel.java
@@ -33,6 +33,7 @@ import inventorysetups.InventorySetupsPlugin;
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_PANEL_VIEW;
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_SECTION_MODE;
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_UNASSIGNED_MAXIMIZED;
+import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_LAST_SETUP_VALUE;
 import static inventorysetups.InventorySetupsPlugin.TUTORIAL_LINK;
 
 import inventorysetups.InventorySetupsSection;
@@ -445,6 +446,7 @@ public class InventorySetupsPluginPanel extends PluginPanel
 				if (SwingUtilities.isLeftMouseButton(e))
 				{
 					redrawOverviewPanel(false);
+					plugin.setConfigValue(CONFIG_KEY_LAST_SETUP_VALUE, "");
 				}
 			}
 
@@ -754,6 +756,7 @@ public class InventorySetupsPluginPanel extends PluginPanel
 		plugin.setBankFilteringMode(InventorySetupsFilteringModeID.ALL);
 		plugin.doBankSearch();
 
+		plugin.setConfigValue(CONFIG_KEY_LAST_SETUP_VALUE, inventorySetup.getName());
 		validate();
 		repaint();
 


### PR DESCRIPTION
Loads on plugin/client startup, the config value is cleared if you close a setups view, prior to closing the client to prevent weird cases of a user getting thrown back into a setup when they didn't want it.

https://github.com/dillydill123/inventory-setups/assets/63735241/fde5640a-5331-449b-9b28-23bc354cfa7a

