### PR TITLE
Toggle fuzzy for all

### DIFF
--- a/src/main/java/inventorysetups/InventorySetupsItem.java
+++ b/src/main/java/inventorysetups/InventorySetupsItem.java
@@ -46,10 +46,6 @@ public class InventorySetupsItem
 	@Setter
 	private InventorySetupsStackCompareID stackCompare;
 
-	public void toggleIsFuzzy()
-	{
-		fuzzy = !fuzzy;
-	}
 
 	public static InventorySetupsItem getDummyItem()
 	{

--- a/src/main/java/inventorysetups/InventorySetupsPlugin.java
+++ b/src/main/java/inventorysetups/InventorySetupsPlugin.java
@@ -1679,7 +1679,7 @@ public class InventorySetupsPlugin extends Plugin
 			final List<InventorySetupsItem> container = getContainerFromSlot(slot);
 			item = container.get(slot.getIndexInSlot());
 		}
-		item.toggleIsFuzzy();
+		item.setFuzzy(!(item.isFuzzy()));
 		final int itemId = item.getId();
 		clientThread.invoke(() ->
 		{
@@ -1694,6 +1694,34 @@ public class InventorySetupsPlugin extends Plugin
 		panel.refreshCurrentSetup();
 	}
 
+	public void toggleAllFuzzyOnSlot(final InventorySetupsSlot slot) {
+		if (panel.getCurrentSelectedSetup() == null) {
+			return;
+		}
+		log.debug("Toggling all the fuzzies");
+		final List<InventorySetupsItem> container = getContainerFromSlot(slot);
+		InventorySetupsItem item = container.get(slot.getIndexInSlot());
+		boolean fuzz = item.isFuzzy();
+
+        for (final InventorySetupsItem eachItem : container) {
+            if (eachItem.getId() == getContainerFromSlot(slot).get(slot.getIndexInSlot()).getId()) {
+                eachItem.setFuzzy(!fuzz);
+            }
+        }
+
+		final int itemId = item.getId();
+		clientThread.invoke(() ->
+		{
+			if (itemId == -1)
+			{
+				return;
+			}
+			layoutUtilities.recalculateLayout(slot.getParentSetup());
+		});
+
+		dataManager.updateConfig(true, false);
+		panel.refreshCurrentSetup();
+	}
 	public void setStackCompareOnSlot(final InventorySetupsSlot slot, final InventorySetupsStackCompareID newStackCompare)
 	{
 		if (panel.getCurrentSelectedSetup() == null)

--- a/src/main/java/inventorysetups/ui/InventorySetupsAdditionalItemsPanel.java
+++ b/src/main/java/inventorysetups/ui/InventorySetupsAdditionalItemsPanel.java
@@ -90,6 +90,7 @@ public class InventorySetupsAdditionalItemsPanel extends InventorySetupsContaine
 			{
 				final InventorySetupsSlot newSlot = new InventorySetupsSlot(ColorScheme.DARKER_GRAY_COLOR, InventorySetupsSlotID.ADDITIONAL_ITEMS, i);
 				InventorySetupsSlot.addFuzzyMouseListenerToSlot(plugin, newSlot);
+				InventorySetupsSlot.addAllFuzzyMouseListenerToSlot(plugin, newSlot);
 				InventorySetupsSlot.addUpdateFromSearchMouseListenerToSlot(plugin, newSlot, false);
 				InventorySetupsSlot.addRemoveMouseListenerToSlot(plugin, newSlot);
 				additionalFilteredSlots.add(newSlot);

--- a/src/main/java/inventorysetups/ui/InventorySetupsEquipmentPanel.java
+++ b/src/main/java/inventorysetups/ui/InventorySetupsEquipmentPanel.java
@@ -60,6 +60,7 @@ public class InventorySetupsEquipmentPanel extends InventorySetupsContainerPanel
 		{
 			final InventorySetupsSlot setupSlot = new InventorySetupsSlot(ColorScheme.DARKER_GRAY_COLOR, InventorySetupsSlotID.EQUIPMENT, slot.getSlotIdx());
 			InventorySetupsSlot.addFuzzyMouseListenerToSlot(plugin, setupSlot);
+			InventorySetupsSlot.addAllFuzzyMouseListenerToSlot(plugin, setupSlot);
 
 			// add stackable configurations for ammo and weapon slots
 			if (slot == EquipmentInventorySlot.AMMO || slot == EquipmentInventorySlot.WEAPON)

--- a/src/main/java/inventorysetups/ui/InventorySetupsInventoryPanel.java
+++ b/src/main/java/inventorysetups/ui/InventorySetupsInventoryPanel.java
@@ -75,6 +75,7 @@ public class InventorySetupsInventoryPanel extends InventorySetupsContainerPanel
 		{
 			containerSlotsPanel.add(inventorySlots.get(i));
 			InventorySetupsSlot.addFuzzyMouseListenerToSlot(plugin, inventorySlots.get(i));
+			InventorySetupsSlot.addAllFuzzyMouseListenerToSlot(plugin, inventorySlots.get(i));
 			InventorySetupsSlot.addStackMouseListenerToSlot(plugin, inventorySlots.get(i));
 			InventorySetupsSlot.addUpdateFromContainerMouseListenerToSlot(plugin, inventorySlots.get(i));
 			InventorySetupsSlot.addUpdateFromSearchMouseListenerToSlot(plugin, inventorySlots.get(i), true);

--- a/src/main/java/inventorysetups/ui/InventorySetupsQuiverPanel.java
+++ b/src/main/java/inventorysetups/ui/InventorySetupsQuiverPanel.java
@@ -48,6 +48,7 @@ public class InventorySetupsQuiverPanel
 		this.itemManager = itemManager;
 		quiverSlot = new InventorySetupsSlot(ColorScheme.DARKER_GRAY_COLOR, InventorySetupsSlotID.QUIVER, QUIVER_SLOT_IDX);
 		InventorySetupsSlot.addFuzzyMouseListenerToSlot(plugin, quiverSlot);
+		InventorySetupsSlot.addAllFuzzyMouseListenerToSlot(plugin, quiverSlot);
 		InventorySetupsSlot.addStackMouseListenerToSlot(plugin, quiverSlot);
 		InventorySetupsSlot.addUpdateFromContainerMouseListenerToSlot(plugin, quiverSlot);
 		InventorySetupsSlot.addUpdateFromSearchMouseListenerToSlot(plugin, quiverSlot, true);

--- a/src/main/java/inventorysetups/ui/InventorySetupsSlot.java
+++ b/src/main/java/inventorysetups/ui/InventorySetupsSlot.java
@@ -257,7 +257,15 @@ public class InventorySetupsSlot extends JPanel
 			plugin.toggleFuzzyOnSlot(slot);
 		});
 	}
-
+	public static void addAllFuzzyMouseListenerToSlot(final InventorySetupsPlugin plugin, final InventorySetupsSlot slot)
+	{
+		JMenuItem makeAllSlotFuzzy = new JMenuItem("Toggle Fuzzy All");
+		slot.getRightClickMenu().add(makeAllSlotFuzzy);
+		makeAllSlotFuzzy.addActionListener(e ->
+		{
+			plugin.toggleAllFuzzyOnSlot(slot);
+		});
+	}
 	// adds the menu option to update set a slot to fuzzy
 	public static void addStackMouseListenerToSlot(final InventorySetupsPlugin plugin, final InventorySetupsSlot slot)
 	{


### PR DESCRIPTION
Adds an option to fuzzy all, which will make all items of the same type fuzzy/nonfuzzy, but only in the one setup. Ironically, the toggle all fuzzy is not fuzzy, so it will only work for items which are exactly the same.

![java_PF8CjN3krD](https://github.com/user-attachments/assets/b5707759-611a-49e3-8a69-6ec68516b02c)

Wording probably needs to be changed, not sure how the menu option should be setup. 

Maybe a separate category of multiple item changers would be helpful. Similar to how shift changes all items across all setups, but only for the current setup. Could use ctrl instead of shift, and add this fuzzy toggle and a change all items option.

Fixes #267 