### PR TITLE
Close setup when bank closes

### DIFF
--- a/src/main/java/inventorysetups/InventorySetupsConfig.java
+++ b/src/main/java/inventorysetups/InventorySetupsConfig.java
@@ -29,6 +29,7 @@ import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_HIDE_BUTTON;
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_LAYOUT_DEFAULT;
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_LAYOUT_DUPLICATES;
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_MANUAL_BANK_FILTER;
+import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_CLOSE_WITH_BANK;
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_PANEL_VIEW;
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_PERSIST_HOTKEYS;
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_SECTION_MODE;
@@ -511,6 +512,16 @@ public interface InventorySetupsConfig extends Config
 		return true;
 	}
 
+	@ConfigItem(
+			keyName = CONFIG_KEY_CLOSE_WITH_BANK,
+			name = "Close with Bank",
+			description = "Close your current setup when you close the bank",
+			section = otherSection
+	)
+	default boolean closeWithBank()
+	{
+		return false;
+	}
 
 
 }

--- a/src/main/java/inventorysetups/InventorySetupsPlugin.java
+++ b/src/main/java/inventorysetups/InventorySetupsPlugin.java
@@ -142,6 +142,7 @@ public class InventorySetupsPlugin extends Plugin
 	public static final String CONFIG_KEY_VERSION_STR = "version";
 	public static final String CONFIG_KEY_UNASSIGNED_MAXIMIZED = "unassignedMaximized";
 	public static final String CONFIG_KEY_MANUAL_BANK_FILTER = "manualBankFilter";
+	public static final String CONFIG_KEY_CLOSE_WITH_BANK = "closeWithBank";
 	public static final String CONFIG_KEY_PERSIST_HOTKEYS = "persistHotKeysOutsideBank";
 	public static final String CONFIG_KEY_USE_LAYOUTS = "useLayouts";
 	public static final String CONFIG_KEY_LAYOUT_DEFAULT = "defaultLayout";
@@ -897,7 +898,11 @@ public class InventorySetupsPlugin extends Plugin
 			{
 				unregisterHotkeys();
 			}
+			if (config.closeWithBank())
+			{
+				clientThread.invokeLater(() -> panel.returnToOverviewPanel(false));
 
+			}
 			if (isInventorySetupTagOpen())
 			{
 				// Close the bank tag for those who use manual bank filter


### PR DESCRIPTION
Adds a config option to close the current setup when exiting the bank. Exactly what #302 is asking for.

![java_oqcQ3XQ5dC](https://github.com/user-attachments/assets/4eabe0d5-ddef-49c6-9f9c-ac42b3a44e97)
