### PR TITLE
Allow Bottom To Top ZigZag Layouts

### DIFF
--- a/src/main/java/inventorysetups/InventorySetupLayoutUtilities.java
+++ b/src/main/java/inventorysetups/InventorySetupLayoutUtilities.java
@@ -97,7 +97,6 @@ public class InventorySetupLayoutUtilities
 		layout.resize(newSizeGuess);
 		final HashMap<Integer, Integer> counter = new HashMap<>();
 
-
 		int nextPos = layoutZigZagContainer(setup.getEquipment(), layout, tag, addToTag, startOfEquipment, counter);
 		if (setup.getQuiver() != null && !setup.getQuiver().isEmpty())
 		{
@@ -152,8 +151,10 @@ public class InventorySetupLayoutUtilities
 		// But this is not needed, so I won't spend time over engineering this function.
 
 		int doubleRowStart = 0;
-		int nextPos = 0;
+		boolean topToBottom = config.zigZagType().equals(InventorySetupsZigZagTypeID.TOP_TO_BOTTOM);
 		final int rowSize = 8;
+
+		int nextPos = topToBottom ? 0 : 8;
 
 		for (final InventorySetupsItem item : container)
 		{
@@ -163,21 +164,43 @@ public class InventorySetupLayoutUtilities
 				continue;
 			}
 
-			if (nextPos == (rowSize * 2) - 1)
+            if (topToBottom)
 			{
-				// We hit the end of a double row, we need to start a new one.
-				doubleRowStart += 2;
-				nextPos = doubleRowStart * rowSize;
-			}
-			else if (nextPos < ((doubleRowStart * rowSize) + rowSize))
-			{
-				// We are in the top half of a double row. Go down directly one.
-				nextPos += rowSize;
-			}
+				if (nextPos == ((doubleRowStart * rowSize) + (2 * rowSize) - 1))
+				{
+					// We hit the end of a double row, we need to start a new one.
+					doubleRowStart += 2;
+					nextPos = doubleRowStart * rowSize;
+				}
+				else if (nextPos < ((doubleRowStart * rowSize) + rowSize))
+				{
+					// We are in the top half of a double row. Go down directly one.
+					nextPos += rowSize;
+				}
+				else
+				{
+					// We are in the bottom half of a double. Go back up and add one to move to the right.
+					nextPos = (nextPos - rowSize) + 1;
+				}
+            }
 			else
 			{
-				// We are in the bottom half of a double. Go back up and add one to move to the right.
-				nextPos = (nextPos - rowSize) + 1;
+				if (nextPos == ((doubleRowStart * rowSize) + rowSize - 1))
+				{
+					// We hit the end of a double row, we need to start a new one.
+					doubleRowStart += 2;
+					nextPos = (doubleRowStart * rowSize) + rowSize;
+				}
+				else if (nextPos > ((doubleRowStart * rowSize) + rowSize) - 1)
+				{
+					// We are in the bottom half of a double. Go up directly one.
+					nextPos -= rowSize;
+				}
+				else
+				{
+					// We are in the top half of a double row. Go back down and add one to move to the right.
+					nextPos = nextPos + rowSize + 1;
+				}
 			}
 		}
 

--- a/src/main/java/inventorysetups/InventorySetupsConfig.java
+++ b/src/main/java/inventorysetups/InventorySetupsConfig.java
@@ -27,6 +27,7 @@ package inventorysetups;
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_ENABLE_LAYOUT_WARNING;
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_HIDE_BUTTON;
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_LAYOUT_DEFAULT;
+import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_ZIGZAG_TYPE;
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_LAYOUT_DUPLICATES;
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_MANUAL_BANK_FILTER;
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_PANEL_VIEW;
@@ -309,6 +310,17 @@ public interface InventorySetupsConfig extends Config
 	default InventorySetupLayoutType defaultLayout()
 	{
 		return InventorySetupLayoutType.PRESET;
+	}
+
+	@ConfigItem(
+			keyName = CONFIG_KEY_ZIGZAG_TYPE,
+			name = "ZigZag Type",
+			description = "Configures ZigZag type when creating or updating a setup",
+			section = layoutSection
+	)
+	default InventorySetupsZigZagTypeID zigZagType()
+	{
+		return InventorySetupsZigZagTypeID.TOP_TO_BOTTOM;
 	}
 
 	@ConfigItem(

--- a/src/main/java/inventorysetups/InventorySetupsPlugin.java
+++ b/src/main/java/inventorysetups/InventorySetupsPlugin.java
@@ -145,6 +145,7 @@ public class InventorySetupsPlugin extends Plugin
 	public static final String CONFIG_KEY_PERSIST_HOTKEYS = "persistHotKeysOutsideBank";
 	public static final String CONFIG_KEY_USE_LAYOUTS = "useLayouts";
 	public static final String CONFIG_KEY_LAYOUT_DEFAULT = "defaultLayout";
+	public static final String CONFIG_KEY_ZIGZAG_TYPE = "zigZagType";
 	public static final String CONFIG_KEY_LAYOUT_DUPLICATES = "addDuplicatesInLayouts";
 	public static final String CONFIG_KEY_ENABLE_LAYOUT_WARNING = "enableLayoutWarning";
 	public static final String CONFIG_GROUP_HUB_BTL = "banktaglayouts";

--- a/src/main/java/inventorysetups/InventorySetupsZigZagTypeID.java
+++ b/src/main/java/inventorysetups/InventorySetupsZigZagTypeID.java
@@ -1,0 +1,33 @@
+package inventorysetups;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+public enum InventorySetupsZigZagTypeID {
+    // Use if you want to withdraw using a top to bottom zigzag pattern
+    TOP_TO_BOTTOM("Top to Bottom", 0),
+
+    // Use if you want to withdraw using a bottom to top zigzag pattern
+    BOTTOM_TO_TOP("Bottom to Top", 1);
+
+    private final int type;
+
+    private static final List<InventorySetupsZigZagTypeID> VALUES;
+
+    static
+    {
+        VALUES = new ArrayList<>();
+        Collections.addAll(VALUES, InventorySetupsZigZagTypeID.values());
+    }
+
+    InventorySetupsZigZagTypeID(String s, int type)
+    {
+        this.type = type;
+    }
+
+    public static List<InventorySetupsZigZagTypeID> getValues()
+    {
+        return VALUES;
+    }
+}


### PR DESCRIPTION
Adds an option to select Top To Bottom or Bottom To Top for ZigZag layouts -  for people with bottom to top muscle memory that want to use this plugin.


![zig-zag-type-ezgif com-video-to-gif-converter(1)](https://github.com/user-attachments/assets/63fa9e7a-921c-4011-abff-7867f882d073)
