### PR TITLE
Enable alpha values (opacity) in highlight color and display color for setups

### DIFF
--- a/src/main/java/inventorysetups/ui/InventorySetupsNameActions.java
+++ b/src/main/java/inventorysetups/ui/InventorySetupsNameActions.java
@@ -328,7 +328,7 @@ public class InventorySetupsNameActions<T extends InventorySetupsDisplayAttribut
 					plugin.openColorPicker("Choose a Display color", currentDisplayColor == null ? JagexColors.MENU_TARGET : currentDisplayColor,
 							c ->
 							{
-								Color newColor = new Color(c.getRed(), c.getGreen(), c.getBlue(), 255);
+								Color newColor = new Color(c.getRed(), c.getGreen(), c.getBlue(), c.getAlpha());
 								updateDisplayColorLabel(newColor);
 							}
 					);

--- a/src/main/java/inventorysetups/ui/InventorySetupsStandardPanel.java
+++ b/src/main/java/inventorysetups/ui/InventorySetupsStandardPanel.java
@@ -318,7 +318,7 @@ public class InventorySetupsStandardPanel extends InventorySetupsPanel implement
 						c ->
 						{
 							// Don't consider the transparency component
-							Color newColor = new Color(c.getRed(), c.getGreen(), c.getBlue(), 255);
+							Color newColor = new Color(c.getRed(), c.getGreen(), c.getBlue(), c.getAlpha());
 							inventorySetup.setHighlightColor(newColor);
 							updateHighlightColorLabel();
 						}


### PR DESCRIPTION
This enables alpha values (opacity) to be respected when selected in the color picker for both `Highlight color` and `Display color`.

<img width="391" height="365" alt="image" src="https://github.com/user-attachments/assets/2284e386-c19a-4818-b23f-138844fc5747" />

<img width="221" height="337" alt="image" src="https://github.com/user-attachments/assets/4c81cc28-083e-496c-a771-057aa984aff9" />
