### PR TITLE
Implement basic filtering to GIM storage

### DIFF
--- a/src/main/java/inventorysetups/InventorySetupsConfig.java
+++ b/src/main/java/inventorysetups/InventorySetupsConfig.java
@@ -31,6 +31,7 @@ import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_PERSIST_HOTKEYS_C
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_USE_OLD_ITEM_SEARCH;
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_ZIGZAG_TYPE;
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_LAYOUT_DUPLICATES;
+import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_FILTER_SHARED_BANK;
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_MANUAL_BANK_FILTER;
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_PANEL_VIEW;
 import static inventorysetups.InventorySetupsPlugin.CONFIG_KEY_PERSIST_HOTKEYS;
@@ -536,6 +537,17 @@ public interface InventorySetupsConfig extends Config
 	default boolean manualBankFilter()
 	{
 		return false;
+	}
+
+	@ConfigItem(
+			keyName = CONFIG_KEY_FILTER_SHARED_BANK,
+			name = "Filter Group Storage",
+			description = "Apply bank filtering to the Group Ironman shared storage when a setup is selected",
+			section = otherSection
+	)
+	default boolean filterSharedBank()
+	{
+		return true;
 	}
 
 	@ConfigItem(

--- a/src/main/java/inventorysetups/InventorySetupsPlugin.java
+++ b/src/main/java/inventorysetups/InventorySetupsPlugin.java
@@ -77,6 +77,7 @@ import net.runelite.api.events.GameTick;
 import net.runelite.api.events.ItemContainerChanged;
 import net.runelite.api.events.MenuEntryAdded;
 import net.runelite.api.events.PostMenuSort;
+import net.runelite.api.events.ScriptPostFired;
 import net.runelite.api.events.ScriptPreFired;
 import net.runelite.api.events.VarbitChanged;
 import net.runelite.api.events.WidgetClosed;
@@ -149,6 +150,7 @@ public class InventorySetupsPlugin extends Plugin
 	public static final String CONFIG_KEY_VERSION_STR = "version";
 	public static final String CONFIG_KEY_UNASSIGNED_MAXIMIZED = "unassignedMaximized";
 	public static final String CONFIG_KEY_MANUAL_BANK_FILTER = "manualBankFilter";
+	public static final String CONFIG_KEY_FILTER_SHARED_BANK = "filterSharedBank";
 	public static final String CONFIG_KEY_PERSIST_HOTKEYS = "persistHotKeysOutsideBank";
 	public static final String CONFIG_KEY_PERSIST_HOTKEYS_CHAT_INPUT = "persistHotKeysDuringChatInput";
 	public static final String CONFIG_KEY_USE_LAYOUTS = "useLayouts";
@@ -283,6 +285,9 @@ public class InventorySetupsPlugin extends Plugin
 	@Getter
 	private InventorySetupsAmmoHandler ammoHandler;
 
+	@Getter
+	private InventorySetupsSharedBankFilter sharedBankFilter;
+
 	// Used to defer highlighting to GameTick
 	private boolean shouldTriggerInventoryHighlightOnGameTick;
 
@@ -357,6 +362,7 @@ public class InventorySetupsPlugin extends Plugin
 		this.sections = new ArrayList<>();
 		this.dataManager = new InventorySetupsPersistentDataManager(this, configManager, cache, gson, inventorySetups, sections);
 		this.ammoHandler = new InventorySetupsAmmoHandler(this, client, itemManager, panel, config);
+		this.sharedBankFilter = new InventorySetupsSharedBankFilter(this, client, panel, config);
 		this.layoutUtilities = new InventorySetupLayoutUtilities(itemManager, tagManager, layoutManager, config, client);
 		this.canUseLayouts = canUseLayouts();
 
@@ -472,7 +478,7 @@ public class InventorySetupsPlugin extends Plugin
 	private void handleRegistrationOfHotkeys()
 	{
 		Widget bankContainer = client.getWidget(InterfaceID.Bankmain.ITEMS);
-		boolean bankIsOpen = bankContainer != null && !bankContainer.isHidden();
+		boolean bankIsOpen = (bankContainer != null && !bankContainer.isHidden()) || sharedBankFilter.isSharedBankOpen();
 
 		// Bank takes priority if hotkeys are disabled.
 		boolean shouldRegisterKeys = bankIsOpen || config.persistHotKeysOutsideBank();
@@ -521,6 +527,10 @@ public class InventorySetupsPlugin extends Plugin
 			else if (event.getKey().equals(CONFIG_KEY_USE_LAYOUTS))
 			{
 				doBankSearch();
+			}
+			else if (event.getKey().equals(CONFIG_KEY_FILTER_SHARED_BANK))
+			{
+				refreshSharedBank();
 			}
 		}
 	}
@@ -960,12 +970,17 @@ public class InventorySetupsPlugin extends Plugin
 				});
 			}
 		}
+		else if (event.getGroupId() == InterfaceID.SHARED_BANK)
+		{
+			// The widget tree is being torn down so there is nothing to un-hide.
+			clientThread.invokeLater(this::handleRegistrationOfHotkeys);
+		}
 	}
 
 	@Subscribe
 	public void onWidgetLoaded(WidgetLoaded event)
 	{
-		if (event.getGroupId() == InterfaceID.BANKMAIN)
+		if (event.getGroupId() == InterfaceID.BANKMAIN || event.getGroupId() == InterfaceID.SHARED_BANK)
 		{
 			clientThread.invokeLater(this::handleRegistrationOfHotkeys);
 		}
@@ -1286,8 +1301,31 @@ public class InventorySetupsPlugin extends Plugin
 				return false;
 			}
 
-			doBankSearch();
+			if (sharedBankFilter.isSharedBankOpen())
+			{
+				refreshSharedBank();
+			}
+			else
+			{
+				doBankSearch();
+			}
 			return true;
+		});
+	}
+
+	// Restores the shared storage to its native state and then re-applies the filter for the current setup.
+	// Used for manual transitions where there is no natural rebuild, e.g. switching/deselecting a setup in
+	// the side panel, toggling the config, or pressing the filter bank hotkey while the storage is open.
+	public void refreshSharedBank()
+	{
+		clientThread.invoke(() ->
+		{
+			if (!sharedBankFilter.isSharedBankOpen())
+			{
+				return;
+			}
+			sharedBankFilter.resetSharedBank();
+			sharedBankFilter.filterSharedBank();
 		});
 	}
 
@@ -1407,6 +1445,20 @@ public class InventorySetupsPlugin extends Plugin
 		{
 			// cancel the current filtering if the search button is clicked
 			resetBankSearch();
+		}
+	}
+
+	@Subscribe
+	public void onScriptPostFired(ScriptPostFired event)
+	{
+		// The shared storage was (re)built (on open and after every deposit/withdraw). We use the POST event
+		// so the item widgets are populated before we filter them.
+		if (event.getScriptId() == ScriptID.GROUP_IRONMAN_STORAGE_BUILD)
+		{
+			if (!config.manualBankFilter())
+			{
+				sharedBankFilter.filterSharedBank();
+			}
 		}
 	}
 

--- a/src/main/java/inventorysetups/InventorySetupsSharedBankFilter.java
+++ b/src/main/java/inventorysetups/InventorySetupsSharedBankFilter.java
@@ -1,0 +1,118 @@
+package inventorysetups;
+
+import inventorysetups.ui.InventorySetupsPluginPanel;
+import net.runelite.api.Client;
+import net.runelite.api.gameval.InterfaceID;
+import net.runelite.api.gameval.ItemID;
+import net.runelite.api.widgets.Widget;
+
+// Handles filtering the Group Ironman shared storage ("shared bank") to match a selected inventory setup.
+// The normal bank filtering is powered by RuneLite's core Bank Tags plugin, which only works on the normal
+// bank (InterfaceID.BANKMAIN) and has no awareness of the shared storage. This is therefore a custom,
+// classic-style filter: it simply hides the item widgets that are not part of the selected setup. Kept items
+// are left exactly where the game placed them (no repositioning), which guarantees that withdrawing always
+// targets the correct storage slot.
+public class InventorySetupsSharedBankFilter
+{
+	private final InventorySetupsPlugin plugin;
+	private final Client client;
+	private final InventorySetupsPluginPanel panel;
+	private final InventorySetupsConfig config;
+
+	public InventorySetupsSharedBankFilter(InventorySetupsPlugin plugin, Client client,
+											InventorySetupsPluginPanel panel, InventorySetupsConfig config)
+	{
+		this.plugin = plugin;
+		this.client = client;
+		this.panel = panel;
+		this.config = config;
+	}
+
+	// True if the Group Ironman shared storage interface is currently open.
+	public boolean isSharedBankOpen()
+	{
+		final Widget itemContainer = client.getWidget(InterfaceID.SharedBank.ITEMS);
+		return itemContainer != null && !itemContainer.isHidden();
+	}
+
+	// Hides every item in the shared storage that is not part of the currently selected setup.
+	// Must be called on the client thread. This is idempotent: a freshly built storage has all items
+	// visible, so re-running it (e.g. after every deposit/withdraw rebuild) reproduces the same result.
+	public void filterSharedBank()
+	{
+		assert client.isClientThread() : "filterSharedBank must be called on the client thread";
+
+		final InventorySetup setup = panel.getCurrentSelectedSetup();
+
+		// Nothing to filter. A freshly built storage is already unfiltered, so just leave it as is.
+		if (setup == null || !setup.isFilterBank() || !config.filterSharedBank() || !plugin.isFilteringAllowed())
+		{
+			return;
+		}
+
+		final Widget itemContainer = client.getWidget(InterfaceID.SharedBank.ITEMS);
+		if (itemContainer == null || itemContainer.isHidden())
+		{
+			return;
+		}
+
+		final Widget[] items = itemContainer.getChildren();
+		if (items == null)
+		{
+			return;
+		}
+
+		for (final Widget item : items)
+		{
+			final int itemId = item.getItemId();
+
+			// Skip non-item children and empty slots (the build script uses BLANKOBJECT for empty slots).
+			if (itemId <= -1 || itemId == ItemID.BLANKOBJECT)
+			{
+				continue;
+			}
+
+			// Storage items are in inventory form, so canonicalize the same way the ground item swapping does.
+			final boolean canonicalize = InventorySetupsVariationMapping.INVERTED_WORN_ITEMS.containsKey(itemId);
+			final boolean keep = plugin.setupContainsItem(setup, itemId, true, canonicalize);
+
+			// Set the hidden state both ways. The storage reuses these widgets across rebuilds, so an item
+			// that should now be shown must be explicitly un-hidden, not just left as it was.
+			item.setHidden(!keep);
+		}
+
+		// NOTE: Only the main shared storage view is filtered. The compact side view
+		// (InterfaceID.SharedBankSide.ITEMS) is intentionally left untouched for now.
+	}
+
+	// Restores the shared storage to its native, unfiltered state by un-hiding every item slot we may have
+	// hidden. Kept items were never moved, so simply un-hiding them puts the storage back as it was.
+	// Must be called on the client thread.
+	public void resetSharedBank()
+	{
+		assert client.isClientThread() : "resetSharedBank must be called on the client thread";
+
+		final Widget itemContainer = client.getWidget(InterfaceID.SharedBank.ITEMS);
+		if (itemContainer == null)
+		{
+			return;
+		}
+
+		final Widget[] items = itemContainer.getChildren();
+		if (items == null)
+		{
+			return;
+		}
+
+		// Only item slots are ever hidden by the filter. Leave empty/non-item children untouched.
+		for (final Widget item : items)
+		{
+			final int itemId = item.getItemId();
+			if (itemId <= -1 || itemId == ItemID.BLANKOBJECT)
+			{
+				continue;
+			}
+			item.setHidden(false);
+		}
+	}
+}

--- a/src/main/java/inventorysetups/ui/InventorySetupsPluginPanel.java
+++ b/src/main/java/inventorysetups/ui/InventorySetupsPluginPanel.java
@@ -786,6 +786,7 @@ public class InventorySetupsPluginPanel extends PluginPanel
 		}
 
 		plugin.doBankSearch();
+		plugin.refreshSharedBank();
 
 		validate();
 		repaint();
@@ -869,6 +870,8 @@ public class InventorySetupsPluginPanel extends PluginPanel
 		currentSelectedSetup = null;
 
 		plugin.resetBankSearch();
+		// Restore the shared storage (if open) now that no setup is selected.
+		plugin.refreshSharedBank();
 
 	}
 

--- a/src/test/java/inventorysetups/InventorySetupsUnitTest.java
+++ b/src/test/java/inventorysetups/InventorySetupsUnitTest.java
@@ -17,6 +17,7 @@ import net.runelite.client.config.RuneLiteConfig;
 import net.runelite.client.game.ItemManager;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import net.runelite.client.plugins.banktags.BankTagsConfig;
 import net.runelite.client.plugins.banktags.BankTagsPlugin;
@@ -135,5 +136,25 @@ public class InventorySetupsUnitTest
 												inventorySetupsConfig.displayColor(), false,false, 0, false, -1, "");
 		inventorySetupsPlugin.startUp();
 		assertFalse(inventorySetupsPlugin.setupContainsItem(setup, ItemID.COAL, true, true));
+	}
+
+	@Test
+	public void testSetupContainsItemForSharedBankFilter()
+	{
+		// The shared bank filter keeps an item only when setupContainsItem returns true for it.
+		List<InventorySetupsItem> inventory = new ArrayList<>(Collections.nCopies(28, InventorySetupsItem.getDummyItem()));
+		inventory.set(0, new InventorySetupsItem(ItemID.COAL, "Coal", 1, false, InventorySetupsStackCompareID.None));
+		List<InventorySetupsItem> equipment = new ArrayList<>(Collections.nCopies(13, InventorySetupsItem.getDummyItem()));
+		List<InventorySetupsItem> runePouch = null;
+		List<InventorySetupsItem> boltPouch = null;
+		List<InventorySetupsItem> quiver = null;
+		Map<Integer, InventorySetupsItem> addItems = new HashMap<>();
+		InventorySetup setup = new InventorySetup(inventory, equipment, runePouch, boltPouch, quiver, addItems, "Test",
+												"", inventorySetupsConfig.highlightColor(), false,
+												inventorySetupsConfig.displayColor(), false, false, 0, false, -1, "");
+		inventorySetupsPlugin.startUp();
+		// Item present in the setup is kept, item not present is hidden.
+		assertTrue(inventorySetupsPlugin.setupContainsItem(setup, ItemID.COAL, true, true));
+		assertFalse(inventorySetupsPlugin.setupContainsItem(setup, ItemID.LOGS, true, true));
 	}
 }


### PR DESCRIPTION
Extends the existing bank-filtering feature to the Group Ironman shared storage. RuneLites core Bank Tags (which powers the normal-bank filter) only works on the regular bank, so this adds a small, custom "classic" filter for the shared bank: when a filtering-enabled setup is selected, items not in the setup are hidden. Matching items are left in place (no repositioning), so withdrawing always targets the correct storage slot.

So it is not as clean as the main bank filtering is, but in my opinion its a good start.

https://github.com/user-attachments/assets/7ffdca4e-5f1d-44cc-a343-0f861a39423f

Would solve #225 

