### PR TITLE
Add PluginMessage API for inter-plugin integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,11 @@ You can export an Inventory Setup to Bank Tag format by right-clicking the expor
 The Bank Tags plugin must be ON to use all features of Inventory Setups, specifically bank layouts and filtering. Inventory Setups will warn the user if filtering and layouts cannot be used. This warning will also provide an option to turn on Bank Tags for you.
 
 Hub Plugin Bank Tag Layouts is not required for Inventory Setups anymore. If you were only using the plugin for Inventory Setups, it's recommended that you uninstall the plugin. If you have layout data from Bank Tag Layouts, Inventory Setups will attempt to migrate the layout data the first time you use the plugin.
+
+### PluginMessage API for Plugin Developers
+
+Other plugins can integrate with Inventory Setups by posting [`PluginMessage`](https://github.com/runelite/runelite/blob/master/runelite-client/src/main/java/net/runelite/client/events/PluginMessage.java) events on the EventBus with the `inventory-setups` namespace. The API supports listing setup names (`get-setups`, plus a `setups-changed` broadcast whenever they change), opening a setup with bank filtering (`view`), and closing the current setup (`clear`). The message names, payload keys, and usage details are documented in [`InventorySetupsPluginMessageHandler`](src/main/java/inventorysetups/InventorySetupsPluginMessageHandler.java).
+
 ## Configuration Settings
 
 In the settings of Inventory Setups, you can change default setup options, key binds, ground item menu options, and other miscellaneous settings.

--- a/src/main/java/inventorysetups/InventorySetupsPersistentDataManager.java
+++ b/src/main/java/inventorysetups/InventorySetupsPersistentDataManager.java
@@ -135,6 +135,9 @@ public class InventorySetupsPersistentDataManager
 
 			final String setupsOrderJson = gson.toJson(setupsOrder);
 			configManager.setConfiguration(CONFIG_GROUP, CONFIG_KEY_SETUPS_ORDER_V3, setupsOrderJson);
+
+			// Setups were just persisted; notify integrating plugins.
+			plugin.broadcastSetupsChanged();
 		}
 
 		if (updateSections)

--- a/src/main/java/inventorysetups/InventorySetupsPlugin.java
+++ b/src/main/java/inventorysetups/InventorySetupsPlugin.java
@@ -181,24 +181,6 @@ public class InventorySetupsPlugin extends Plugin
 	private static final int SPELLBOOK_VARBIT = 4070;
 	private static final int BANK_TAG_OPTIONS = BankTagsService.OPTION_ALLOW_MODIFICATIONS | BankTagsService.OPTION_HIDE_TAG_NAME;
 
-	// PluginMessage API for other plugins to list and open/clear inventory setups. See #415.
-	public static final String API_NAMESPACE = "inventory-setups";
-	// Bumped when the contract below changes in a breaking way. Shipped in setups-changed as data["version"].
-	public static final int API_VERSION = 1;
-	// out: broadcast when the setups change. data["setups"] = List<String> of names, data["version"] = int.
-	public static final String API_MSG_SETUPS_CHANGED = "setups-changed";
-	// in: list setups on demand (for plugins that start after us). Put a mutable Collection<String> under
-	// "setups"; it is filled synchronously with the current setup names.
-	public static final String API_MSG_GET_SETUPS = "get-setups";
-	// in: open a setup, filtering the bank like the worn items menu. data["setup"] = name.
-	public static final String API_MSG_VIEW = "view";
-	// in: clear the current setup (like worn items "Close current setup"). data["setup"] = name to clear
-	// only when it is the active setup; omit to clear whatever is active.
-	public static final String API_MSG_CLEAR = "clear";
-	public static final String API_DATA_SETUPS = "setups";
-	public static final String API_DATA_SETUP = "setup";
-	public static final String API_DATA_VERSION = "version";
-
 	@Inject
 	@Getter
 	private Client client;
@@ -306,6 +288,9 @@ public class InventorySetupsPlugin extends Plugin
 	@Getter
 	private InventorySetupsAmmoHandler ammoHandler;
 
+	@Getter
+	private InventorySetupsPluginMessageHandler pluginMessageHandler;
+
 	// Used to defer highlighting to GameTick
 	private boolean shouldTriggerInventoryHighlightOnGameTick;
 
@@ -380,6 +365,7 @@ public class InventorySetupsPlugin extends Plugin
 		this.sections = new ArrayList<>();
 		this.dataManager = new InventorySetupsPersistentDataManager(this, configManager, cache, gson, inventorySetups, sections);
 		this.ammoHandler = new InventorySetupsAmmoHandler(this, client, itemManager, panel, config);
+		this.pluginMessageHandler = new InventorySetupsPluginMessageHandler(this, clientThread, eventBus, panel);
 		this.layoutUtilities = new InventorySetupLayoutUtilities(itemManager, tagManager, layoutManager, config, client);
 		this.canUseLayouts = canUseLayouts();
 
@@ -2678,107 +2664,17 @@ public class InventorySetupsPlugin extends Plugin
 		// config will already be updated by caller so no need to update it here
 	}
 
-	// Immutable snapshot of the setup names, republished on every change. Lets get-setups answer from any
-	// thread without touching the live list. Only written on the mutating thread (see broadcastSetupsChanged).
-	private volatile List<String> setupNamesSnapshot = List.of();
-
-	private List<String> buildSetupNames()
-	{
-		final List<String> names = new ArrayList<>(inventorySetups.size());
-		for (final InventorySetup setup : inventorySetups)
-		{
-			names.add(setup.getName());
-		}
-		return List.copyOf(names);
-	}
-
-	// Refresh the snapshot and notify listeners. Serialized onto the client thread because setups are
-	// mutated from both the client thread and the Swing EDT. Skips the post when the name list is unchanged,
-	// since updateConfig also fires on slot and note edits.
+	// Called by the data manager whenever setups are persisted; the handler decides whether a broadcast
+	// is actually needed.
 	public void broadcastSetupsChanged()
 	{
-		clientThread.invoke(() ->
-		{
-			final List<String> names = buildSetupNames();
-			if (names.equals(setupNamesSnapshot))
-			{
-				return;
-			}
-			setupNamesSnapshot = names;
-			eventBus.post(new PluginMessage(API_NAMESPACE, API_MSG_SETUPS_CHANGED,
-				Map.of(API_DATA_SETUPS, names, API_DATA_VERSION, API_VERSION)));
-		});
+		pluginMessageHandler.broadcastSetupsChanged();
 	}
 
 	@Subscribe
 	public void onPluginMessage(final PluginMessage message)
 	{
-		if (!API_NAMESPACE.equals(message.getNamespace())
-			|| API_MSG_SETUPS_CHANGED.equals(message.getName()))
-		{
-			// Ignore other namespaces and our own outgoing broadcast.
-			return;
-		}
-
-		switch (message.getName())
-		{
-			case API_MSG_GET_SETUPS:
-			{
-				final Object container = message.getData().get(API_DATA_SETUPS);
-				if (container instanceof Collection)
-				{
-					// eventBus.post is synchronous, so the caller's collection is filled before its own
-					// post() call returns.
-					//noinspection unchecked
-					((Collection<String>) container).addAll(setupNamesSnapshot);
-				}
-				break;
-			}
-			case API_MSG_VIEW:
-			{
-				final Object nameObj = message.getData().get(API_DATA_SETUP);
-				if (!(nameObj instanceof String))
-				{
-					break;
-				}
-				final String targetName = (String) nameObj;
-				// Resolve and apply on the client thread, where inventorySetups is otherwise accessed.
-				clientThread.invoke(() ->
-				{
-					final InventorySetup target = inventorySetups.stream()
-						.filter(setup -> setup.getName().equals(targetName))
-						.findFirst()
-						.orElse(null);
-					if (target == null)
-					{
-						log.debug("Ignoring view request for unknown setup '{}'", targetName);
-						return;
-					}
-					panel.setCurrentInventorySetup(target, true);
-				});
-				break;
-			}
-			case API_MSG_CLEAR:
-			{
-				final Object nameObj = message.getData().get(API_DATA_SETUP);
-				clientThread.invoke(() ->
-				{
-					final InventorySetup current = panel.getCurrentSelectedSetup();
-					if (current == null)
-					{
-						return;
-					}
-					// If a setup name is given, only clear when it is the one currently shown, so a caller
-					// never closes a setup the user switched to themselves.
-					if (nameObj instanceof String && !current.getName().equals(nameObj))
-					{
-						return;
-					}
-					panel.returnToOverviewPanel(false);
-				});
-				break;
-			}
-		}
+		pluginMessageHandler.handleMessage(message);
 	}
 
 }

--- a/src/main/java/inventorysetups/InventorySetupsPlugin.java
+++ b/src/main/java/inventorysetups/InventorySetupsPlugin.java
@@ -87,9 +87,11 @@ import net.runelite.api.vars.InputType;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
+import net.runelite.client.eventbus.EventBus;
 import net.runelite.client.eventbus.Subscribe;
 import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.events.PluginChanged;
+import net.runelite.client.events.PluginMessage;
 import net.runelite.client.events.ProfileChanged;
 import net.runelite.client.game.ItemManager;
 import net.runelite.client.game.SpriteManager;
@@ -179,6 +181,24 @@ public class InventorySetupsPlugin extends Plugin
 	private static final int SPELLBOOK_VARBIT = 4070;
 	private static final int BANK_TAG_OPTIONS = BankTagsService.OPTION_ALLOW_MODIFICATIONS | BankTagsService.OPTION_HIDE_TAG_NAME;
 
+	// PluginMessage API for other plugins to list and open/clear inventory setups. See #415.
+	public static final String API_NAMESPACE = "inventory-setups";
+	// Bumped when the contract below changes in a breaking way. Shipped in setups-changed as data["version"].
+	public static final int API_VERSION = 1;
+	// out: broadcast when the setups change. data["setups"] = List<String> of names, data["version"] = int.
+	public static final String API_MSG_SETUPS_CHANGED = "setups-changed";
+	// in: list setups on demand (for plugins that start after us). Put a mutable Collection<String> under
+	// "setups"; it is filled synchronously with the current setup names.
+	public static final String API_MSG_GET_SETUPS = "get-setups";
+	// in: open a setup, filtering the bank like the worn items menu. data["setup"] = name.
+	public static final String API_MSG_VIEW = "view";
+	// in: clear the current setup (like worn items "Close current setup"). data["setup"] = name to clear
+	// only when it is the active setup; omit to clear whatever is active.
+	public static final String API_MSG_CLEAR = "clear";
+	public static final String API_DATA_SETUPS = "setups";
+	public static final String API_DATA_SETUP = "setup";
+	public static final String API_DATA_VERSION = "version";
+
 	@Inject
 	@Getter
 	private Client client;
@@ -200,6 +220,9 @@ public class InventorySetupsPlugin extends Plugin
 
 	@Inject
 	private ConfigManager configManager;
+
+	@Inject
+	private EventBus eventBus;
 
 	@Inject
 	@Getter
@@ -382,6 +405,7 @@ public class InventorySetupsPlugin extends Plugin
 			{
 				dataManager.loadConfig();
 				handleRegistrationOfHotkeys();
+				broadcastSetupsChanged();
 				SwingUtilities.invokeLater(() -> panel.redrawOverviewPanel(true));
 			});
 
@@ -2652,6 +2676,109 @@ public class InventorySetupsPlugin extends Plugin
 		cache.updateSectionName(section, newName);
 		section.setName(newName);
 		// config will already be updated by caller so no need to update it here
+	}
+
+	// Immutable snapshot of the setup names, republished on every change. Lets get-setups answer from any
+	// thread without touching the live list. Only written on the mutating thread (see broadcastSetupsChanged).
+	private volatile List<String> setupNamesSnapshot = List.of();
+
+	private List<String> buildSetupNames()
+	{
+		final List<String> names = new ArrayList<>(inventorySetups.size());
+		for (final InventorySetup setup : inventorySetups)
+		{
+			names.add(setup.getName());
+		}
+		return List.copyOf(names);
+	}
+
+	// Refresh the snapshot and notify listeners. Serialized onto the client thread because setups are
+	// mutated from both the client thread and the Swing EDT. Skips the post when the name list is unchanged,
+	// since updateConfig also fires on slot and note edits.
+	public void broadcastSetupsChanged()
+	{
+		clientThread.invoke(() ->
+		{
+			final List<String> names = buildSetupNames();
+			if (names.equals(setupNamesSnapshot))
+			{
+				return;
+			}
+			setupNamesSnapshot = names;
+			eventBus.post(new PluginMessage(API_NAMESPACE, API_MSG_SETUPS_CHANGED,
+				Map.of(API_DATA_SETUPS, names, API_DATA_VERSION, API_VERSION)));
+		});
+	}
+
+	@Subscribe
+	public void onPluginMessage(final PluginMessage message)
+	{
+		if (!API_NAMESPACE.equals(message.getNamespace())
+			|| API_MSG_SETUPS_CHANGED.equals(message.getName()))
+		{
+			// Ignore other namespaces and our own outgoing broadcast.
+			return;
+		}
+
+		switch (message.getName())
+		{
+			case API_MSG_GET_SETUPS:
+			{
+				final Object container = message.getData().get(API_DATA_SETUPS);
+				if (container instanceof Collection)
+				{
+					// eventBus.post is synchronous, so the caller's collection is filled before its own
+					// post() call returns.
+					//noinspection unchecked
+					((Collection<String>) container).addAll(setupNamesSnapshot);
+				}
+				break;
+			}
+			case API_MSG_VIEW:
+			{
+				final Object nameObj = message.getData().get(API_DATA_SETUP);
+				if (!(nameObj instanceof String))
+				{
+					break;
+				}
+				final String targetName = (String) nameObj;
+				// Resolve and apply on the client thread, where inventorySetups is otherwise accessed.
+				clientThread.invoke(() ->
+				{
+					final InventorySetup target = inventorySetups.stream()
+						.filter(setup -> setup.getName().equals(targetName))
+						.findFirst()
+						.orElse(null);
+					if (target == null)
+					{
+						log.debug("Ignoring view request for unknown setup '{}'", targetName);
+						return;
+					}
+					panel.setCurrentInventorySetup(target, true);
+				});
+				break;
+			}
+			case API_MSG_CLEAR:
+			{
+				final Object nameObj = message.getData().get(API_DATA_SETUP);
+				clientThread.invoke(() ->
+				{
+					final InventorySetup current = panel.getCurrentSelectedSetup();
+					if (current == null)
+					{
+						return;
+					}
+					// If a setup name is given, only clear when it is the one currently shown, so a caller
+					// never closes a setup the user switched to themselves.
+					if (nameObj instanceof String && !current.getName().equals(nameObj))
+					{
+						return;
+					}
+					panel.returnToOverviewPanel(false);
+				});
+				break;
+			}
+		}
 	}
 
 }

--- a/src/main/java/inventorysetups/InventorySetupsPlugin.java
+++ b/src/main/java/inventorysetups/InventorySetupsPlugin.java
@@ -2050,6 +2050,7 @@ public class InventorySetupsPlugin extends Plugin
 		clientThread.invokeLater(() ->
 		{
 			dataManager.loadConfig();
+			broadcastSetupsChanged();
 			// We may need to display the warning for this profile so reset it.
 			panel.setHasDisplayedLayoutWarning(false);
 			SwingUtilities.invokeLater(() -> panel.redrawOverviewPanel(true));

--- a/src/main/java/inventorysetups/InventorySetupsPluginMessageHandler.java
+++ b/src/main/java/inventorysetups/InventorySetupsPluginMessageHandler.java
@@ -1,0 +1,178 @@
+package inventorysetups;
+
+import inventorysetups.ui.InventorySetupsPluginPanel;
+import lombok.extern.slf4j.Slf4j;
+import net.runelite.client.callback.ClientThread;
+import net.runelite.client.eventbus.EventBus;
+import net.runelite.client.events.PluginMessage;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+// PluginMessage API for other plugins to list and open/clear inventory setups. See #415.
+@Slf4j
+public class InventorySetupsPluginMessageHandler
+{
+	public static final String API_NAMESPACE = "inventory-setups";
+	// Bumped when the contract below changes in a breaking way. Shipped in setups-changed as data["version"].
+	public static final int API_VERSION = 1;
+	// out: broadcast when the setups change. data["setups"] = List<String> of names, data["version"] = int.
+	public static final String API_MSG_SETUPS_CHANGED = "setups-changed";
+	// in: list setups on demand (for plugins that start after us). Put a mutable Collection<String> under
+	// "setups"; it is filled synchronously with the current setup names.
+	public static final String API_MSG_GET_SETUPS = "get-setups";
+	// in: open a setup, filtering the bank like the worn items menu. data["setup"] = name.
+	public static final String API_MSG_VIEW = "view";
+	// in: clear the current setup (like worn items "Close current setup"). data["setup"] = name to clear
+	// only when it is the active setup; omit to clear whatever is active.
+	public static final String API_MSG_CLEAR = "clear";
+	public static final String API_DATA_SETUPS = "setups";
+	public static final String API_DATA_SETUP = "setup";
+	public static final String API_DATA_VERSION = "version";
+
+	private final InventorySetupsPlugin plugin;
+	private final ClientThread clientThread;
+	private final EventBus eventBus;
+	private final InventorySetupsPluginPanel panel;
+
+	// Immutable snapshot of the setup names, republished on every change. Lets get-setups answer from any
+	// thread without touching the live list. Only written on the client thread (see broadcastSetupsChanged).
+	private volatile List<String> setupNamesSnapshot = List.of();
+
+	public InventorySetupsPluginMessageHandler(InventorySetupsPlugin plugin, ClientThread clientThread,
+												EventBus eventBus, InventorySetupsPluginPanel panel)
+	{
+		this.plugin = plugin;
+		this.clientThread = clientThread;
+		this.eventBus = eventBus;
+		this.panel = panel;
+	}
+
+	// Refresh the snapshot and notify listeners. Serialized onto the client thread because setups are
+	// mutated from both the client thread and the Swing EDT. Skips the post when the name list is unchanged,
+	// since updateConfig also fires on slot and note edits.
+	public void broadcastSetupsChanged()
+	{
+		clientThread.invoke(() ->
+		{
+			final List<String> names = buildSetupNames();
+			if (names.equals(setupNamesSnapshot))
+			{
+				return;
+			}
+			setupNamesSnapshot = names;
+			eventBus.post(new PluginMessage(API_NAMESPACE, API_MSG_SETUPS_CHANGED,
+				Map.of(API_DATA_SETUPS, names, API_DATA_VERSION, API_VERSION)));
+		});
+	}
+
+	public void handleMessage(final PluginMessage message)
+	{
+		if (!API_NAMESPACE.equals(message.getNamespace()))
+		{
+			return;
+		}
+		if (API_MSG_SETUPS_CHANGED.equals(message.getName()))
+		{
+			// Our own outgoing broadcast.
+			return;
+		}
+
+		switch (message.getName())
+		{
+			case API_MSG_GET_SETUPS:
+			{
+				handleGetSetups(message);
+				break;
+			}
+			case API_MSG_VIEW:
+			{
+				handleView(message);
+				break;
+			}
+			case API_MSG_CLEAR:
+			{
+				handleClear(message);
+				break;
+			}
+			default:
+			{
+				log.debug("Ignoring unsupported message '{}' in the {} namespace", message.getName(), API_NAMESPACE);
+				break;
+			}
+		}
+	}
+
+	private void handleGetSetups(final PluginMessage message)
+	{
+		final Object container = message.getData().get(API_DATA_SETUPS);
+		if (container instanceof Collection)
+		{
+			// eventBus.post is synchronous, so the caller's collection is filled before its own
+			// post() call returns.
+			//noinspection unchecked
+			((Collection<String>) container).addAll(setupNamesSnapshot);
+		}
+	}
+
+	private void handleView(final PluginMessage message)
+	{
+		final Object nameObj = message.getData().get(API_DATA_SETUP);
+		if (!(nameObj instanceof String))
+		{
+			return;
+		}
+		final String targetName = (String) nameObj;
+		// Resolve and apply on the client thread, where the setups are otherwise accessed.
+		clientThread.invoke(() ->
+		{
+			final InventorySetup target = plugin.getInventorySetups().stream()
+				.filter(setup -> setup.getName().equals(targetName))
+				.findFirst()
+				.orElse(null);
+			if (target == null)
+			{
+				log.debug("Ignoring view request for unknown setup '{}'", targetName);
+				return;
+			}
+			panel.setCurrentInventorySetup(target, true);
+		});
+	}
+
+	private void handleClear(final PluginMessage message)
+	{
+		final Object nameObj = message.getData().get(API_DATA_SETUP);
+		clientThread.invoke(() ->
+		{
+			final InventorySetup current = panel.getCurrentSelectedSetup();
+			if (current == null)
+			{
+				return;
+			}
+			if (nameObj == null)
+			{
+				// No name given: clear whatever setup is active.
+				panel.returnToOverviewPanel(false);
+				return;
+			}
+			// A name was given: only clear when it is the setup currently shown, so a caller never
+			// closes a setup the user switched to themselves.
+			if (current.getName().equals(nameObj))
+			{
+				panel.returnToOverviewPanel(false);
+			}
+		});
+	}
+
+	private List<String> buildSetupNames()
+	{
+		final List<String> names = new ArrayList<>(plugin.getInventorySetups().size());
+		for (final InventorySetup setup : plugin.getInventorySetups())
+		{
+			names.add(setup.getName());
+		}
+		return List.copyOf(names);
+	}
+}

--- a/src/main/java/inventorysetups/InventorySetupsPluginMessageHandler.java
+++ b/src/main/java/inventorysetups/InventorySetupsPluginMessageHandler.java
@@ -12,6 +12,18 @@ import java.util.List;
 import java.util.Map;
 
 // PluginMessage API for other plugins to list and open/clear inventory setups. See #415.
+//
+// To use this from another plugin, post a PluginMessage on the EventBus with the "inventory-setups"
+// namespace, e.g.:
+//
+//   Map<String, Object> data = new HashMap<>();
+//   data.put("setup", "Vorkath");
+//   eventBus.post(new PluginMessage("inventory-setups", "view", data));
+//
+// Supported messages are documented on the constants below. To track the available setups, subscribe
+// to PluginMessage and listen for "setups-changed" broadcasts, and post "get-setups" once on startup
+// (posting is synchronous, so the collection you pass is filled before post() returns). Payload values
+// are plain JDK types (String, int, Collection<String>) so they are visible across plugin classloaders.
 @Slf4j
 public class InventorySetupsPluginMessageHandler
 {
@@ -99,7 +111,7 @@ public class InventorySetupsPluginMessageHandler
 			}
 			default:
 			{
-				log.debug("Ignoring unsupported message '{}' in the {} namespace", message.getName(), API_NAMESPACE);
+				log.warn("Ignoring unsupported message '{}' in the {} namespace", message.getName(), API_NAMESPACE);
 				break;
 			}
 		}
@@ -107,7 +119,7 @@ public class InventorySetupsPluginMessageHandler
 
 	private void handleGetSetups(final PluginMessage message)
 	{
-		final Object container = message.getData().get(API_DATA_SETUPS);
+		final Object container = message.getData().getOrDefault(API_DATA_SETUPS, null);
 		if (container instanceof Collection)
 		{
 			// eventBus.post is synchronous, so the caller's collection is filled before its own
@@ -115,13 +127,18 @@ public class InventorySetupsPluginMessageHandler
 			//noinspection unchecked
 			((Collection<String>) container).addAll(setupNamesSnapshot);
 		}
+		else
+		{
+			log.warn("Ignoring {} message without a Collection under '{}'", API_MSG_GET_SETUPS, API_DATA_SETUPS);
+		}
 	}
 
 	private void handleView(final PluginMessage message)
 	{
-		final Object nameObj = message.getData().get(API_DATA_SETUP);
+		final Object nameObj = message.getData().getOrDefault(API_DATA_SETUP, null);
 		if (!(nameObj instanceof String))
 		{
+			log.warn("Ignoring {} message without a String under '{}'", API_MSG_VIEW, API_DATA_SETUP);
 			return;
 		}
 		final String targetName = (String) nameObj;
@@ -134,7 +151,7 @@ public class InventorySetupsPluginMessageHandler
 				.orElse(null);
 			if (target == null)
 			{
-				log.debug("Ignoring view request for unknown setup '{}'", targetName);
+				log.warn("Ignoring view request for unknown setup '{}'", targetName);
 				return;
 			}
 			panel.setCurrentInventorySetup(target, true);
@@ -143,7 +160,12 @@ public class InventorySetupsPluginMessageHandler
 
 	private void handleClear(final PluginMessage message)
 	{
-		final Object nameObj = message.getData().get(API_DATA_SETUP);
+		final Object nameObj = message.getData().getOrDefault(API_DATA_SETUP, null);
+		if (nameObj != null && !(nameObj instanceof String))
+		{
+			log.warn("Ignoring {} message with a non-String value under '{}'", API_MSG_CLEAR, API_DATA_SETUP);
+			return;
+		}
 		clientThread.invoke(() ->
 		{
 			final InventorySetup current = panel.getCurrentSelectedSetup();


### PR DESCRIPTION
# Add PluginMessage API for inter-plugin integration

Addresses #415.

## Summary

Adds a `PluginMessage` API under the `inventory-setups` namespace so other plugins can list setups and open or clear them, without reading the config keys or reimplementing the layout tag hashing.

## Messages (namespace `inventory-setups`)

| Direction | name | data | behavior |
|---|---|---|---|
| out | `setups-changed` | `setups`: `List<String>`, `version`: `int` | broadcast on startup and whenever the set of setups changes |
| in | `get-setups` | `setups`: mutable `Collection<String>` | filled synchronously with the current setup names |
| in | `view` | `setup`: `String` | opens the setup and filters the bank, same as the worn items menu |
| in | `clear` | `setup`: `String` (optional) | clears the current setup; if a name is given, only when it is the active one |

## Performance

- The broadcast piggybacks on `updateConfig`, which already serializes every setup to config on each change, so building a `List<String>` of names next to that is negligible.
- It only fires on add, remove, rename, import and reorder, never per tick or per frame, and it skips the post when the name list is unchanged, so slot and note edits do not broadcast.
- The build and post run on the client thread, and `get-setups` is answered from a `volatile` immutable snapshot, so it is safe to call from any thread.

## Versioning

`setups-changed` carries a `version` field (`API_VERSION`, currently 1) so consumers can detect future breaking changes.

## Testing

Verified end to end against a consumer plugin (a radial ring menu): startup broadcast, live add / rename / delete updates, bank filtering, and name-scoped clear, including both load orders (consumer first and inventory setups first).
