### PR TITLE
Fix translucent highlight ghosting and add live color preview

### DIFF
--- a/src/main/java/inventorysetups/ui/InventorySetupsNameActions.java
+++ b/src/main/java/inventorysetups/ui/InventorySetupsNameActions.java
@@ -328,7 +328,7 @@ public class InventorySetupsNameActions<T extends InventorySetupsDisplayAttribut
 					plugin.openColorPicker("Choose a Display color", currentDisplayColor == null ? JagexColors.MENU_TARGET : currentDisplayColor,
 							c ->
 							{
-								Color newColor = new Color(c.getRed(), c.getGreen(), c.getBlue(), 255);
+								Color newColor = new Color(c.getRed(), c.getGreen(), c.getBlue(), c.getAlpha());
 								updateDisplayColorLabel(newColor);
 							}
 					);

--- a/src/main/java/inventorysetups/ui/InventorySetupsSlot.java
+++ b/src/main/java/inventorysetups/ui/InventorySetupsSlot.java
@@ -34,13 +34,14 @@ import inventorysetups.InventorySetupsVariationMapping;
 import lombok.Getter;
 import lombok.Setter;
 import net.runelite.client.game.ItemManager;
-import net.runelite.client.ui.ColorScheme;
 import net.runelite.client.ui.FontManager;
 import net.runelite.client.util.AsyncBufferedImage;
 
 import javax.swing.*;
 import java.awt.Color;
 import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
@@ -75,6 +76,8 @@ public class InventorySetupsSlot extends JPanel
 	@Getter
 	private JPopupMenu shiftRightClickMenu;
 
+	private final Color defaultBackgroundColor;
+
 	public static final int SLOT_WIDTH = 46;
 	public static final int SLOT_HEIGHT = 42;
 
@@ -85,6 +88,7 @@ public class InventorySetupsSlot extends JPanel
 
 	public InventorySetupsSlot(Color color, InventorySetupsSlotID id, int indexInSlot, int width, int height)
 	{
+		this.defaultBackgroundColor = color;
 		this.slotID = id;
 		this.imageLabel = new JLabel();
 		this.parentSetup = null;
@@ -129,6 +133,11 @@ public class InventorySetupsSlot extends JPanel
 		this.imageLabel.addMouseListener(menuAdapter);
 
 		setPreferredSize(new Dimension(width, height));
+
+		// Swing assumes opaque components paint an opaque background. If the
+		// background color has an alpha < 255, previous pixels may show through.
+		// We set Slots to be non-opaque and handle painting ourselves in `PaintComponent`.
+		setOpaque(false);
 		setBackground(color);
 		setLayout(new GridBagLayout());
 
@@ -143,6 +152,34 @@ public class InventorySetupsSlot extends JPanel
 		add(imageLabel);
 		add(fuzzyIndicator, fuzzyConstraints);
 		add(stackIndicator, stackConstraints);
+	}
+
+	@Override
+	protected void paintComponent(Graphics g)
+	{
+		// Since this panel is non-opaque, Swing does not clear its background.
+		// Paint an opaque default background first so translucent background
+		// colors don't blend with pixels from previous repaints.
+		Graphics2D g2d = (Graphics2D) g.create();
+		try
+		{
+			g2d.setColor(defaultBackgroundColor);
+			g2d.fillRect(0, 0, getWidth(), getHeight());
+
+			Color bg = getBackground();
+			if (bg != null && !bg.equals(defaultBackgroundColor))
+			{
+				g2d.setColor(bg);
+				g2d.fillRect(0, 0, getWidth(), getHeight());
+			}
+		}
+		finally
+		{
+			g2d.dispose();
+		}
+
+		// Call super last to paint images and text over the now correctly filled-in background
+		super.paintComponent(g);
 	}
 
 	public void setImageLabel(String toolTip, BufferedImage itemImage, boolean isFuzzy, InventorySetupsStackCompareID stackCompare)
@@ -399,7 +436,7 @@ public class InventorySetupsSlot extends JPanel
 
 	public static void doResetHighlight(final InventorySetupsSlot containerSlot)
 	{
-		containerSlot.setBackground(ColorScheme.DARKER_GRAY_COLOR);
+		containerSlot.setBackground(containerSlot.defaultBackgroundColor);
 	}
 
 	public static boolean shouldHighlightSlotBasedOnStack(final InventorySetupsStackCompareID stackCompareType, final Integer savedItemQty, final Integer currItemQty)

--- a/src/main/java/inventorysetups/ui/InventorySetupsStandardPanel.java
+++ b/src/main/java/inventorysetups/ui/InventorySetupsStandardPanel.java
@@ -317,9 +317,7 @@ public class InventorySetupsStandardPanel extends InventorySetupsPanel implement
 					plugin.openColorPicker("Choose a Highlight color", invSetup.getHighlightColor(),
 						c ->
 						{
-							// Don't consider the transparency component
-							Color newColor = new Color(c.getRed(), c.getGreen(), c.getBlue(), 255);
-							inventorySetup.setHighlightColor(newColor);
+							inventorySetup.setHighlightColor(c);
 							updateHighlightColorLabel();
 						}
 					);


### PR DESCRIPTION
> [!IMPORTANT]
> @jarromie had originally re-implemented support for Alpha/Opacity in highlights.
> This PR combines their work with a fix for a merge-blocking bug + a few Quality of Life updates for color selection.

# Summary
- Fix visual ghosting and alpha stacking when using semi-transparent highlight colors on inventory setup slots
- Re-enable alpha support in the highlight and display color pickers (previously hard-coded to 255 due to the bug we fix here)
- Refresh slot highlighting live while the color picker is open and the same setup is being viewed
- Add a "Change highlight color" button above setups that have highlighting enabled

# The Ghosting Problem

Translucent highlight colors were applied via `setBackground()` on opaque `JPanel` slots (`InventorySetupsSlot`). Swing does not handle this correctly: semi-transparent fills blend over stale buffer pixels instead of clearing them first. 

This caused:

- Ghosted item icons and RuneLite UI bleeding into slots (especially on first open after changing alpha)
- Highlight opacity accumulating on repeated `doHighlighting()` calls (e.g. alpha 150 layered twice appearing nearly solid)
- Artifacts that cleared after scrolling or re-opening a setup

Alpha had been disabled in the color picker callbacks as a workaround.
<img width="232" height="470" alt="617264197-d6eb798e-0814-4fae-a088-04ee1903ed24" src="https://github.com/user-attachments/assets/abf0af73-93ba-47a3-9d2e-e2cfec4d6bfc" />


## Solution

**Ghosting fix (`InventorySetupsSlot`):**
- `setOpaque(false)` so Swing does not auto-fill with a broken translucent background
- Custom `paintComponent()` that always fills the slot's opaque base color first, then draws the highlight color in a single paint pass
- `doResetHighlight()` restores each slot's constructor-provided default background
- 
**Transparency re-enabled:**
- Highlight color picker passes the full picked `Color` (including alpha)
- Display color picker preserves alpha via `c.getAlpha()`

# Quality of Life Updates
## Live color preview
- When the highlight color changes and that setup is already open in the detail view, re-run highlighting immediately so slots update without closing/reopening the setup
- The paint bucket underline has been given the same live updating behavior

## In-Setup Color Picker
- Added a "Change highlight color" element that opens the color picker. This provides a better user experience than needing to back out of a setup to change its coloring. 
- This element only shows if highlighting is enabled for the current setup, otherwise it is hidden.
- Color picker now opens to the left of the cursor. Creation now handled by `positionColorPickerLeftOfCursor`. This was done to prevent the color picker from being created half off-screen and half on-screen. 

# Live Demo

https://github.com/user-attachments/assets/5265ec4c-0f6a-4a63-92db-6ce7434790dd

