### PR TITLE
include missing items in ge search

### DIFF
--- a/src/main/java/inventorysetups/chatbox/InventorySetupsChatboxItemSearchFilter.java
+++ b/src/main/java/inventorysetups/chatbox/InventorySetupsChatboxItemSearchFilter.java
@@ -64,6 +64,11 @@ public class InventorySetupsChatboxItemSearchFilter
 
 		for (int id = 0; id < highestItemID; id++)
 		{
+			if (idsToFilter.contains(id))
+			{
+				continue;
+			}
+
 			ItemComposition itemComp = itemManager.getItemComposition(id);
 			// Skip noted and placeholder items.
 			if (itemComp.getNote() != -1 || itemComp.getPlaceholderTemplateId() != -1)


### PR DESCRIPTION
Fixes #421
[filtered-after-clean.txt](https://github.com/user-attachments/files/30452233/filtered-after-clean.txt)
[filtered-before-clean.txt](https://github.com/user-attachments/files/30452235/filtered-before-clean.txt)

I've included the items that were filtered before and after this change. The items that are affected by this change are:
```
FILTERED        3842    Unholy book     tradeable=false canonical=3842                <=           
FILTERED        6107    Ghostly robe    tradeable=false canonical=6107               <=           
FILTERED        6108    Ghostly robe    tradeable=false canonical=6108               <=           
FILTERED        6109    Ghostly hood    tradeable=false canonical=6109               <=           
FILTERED        7458    Mithril gloves  tradeable=false canonical=7458             <=           
FILTERED        7459    Adamant gloves  tradeable=false canonical=7459             <=           
FILTERED        7460    Rune gloves     tradeable=false canonical=7460                <=           
FILTERED        7462    Barrows gloves  tradeable=false canonical=7462             <=           
FILTERED        8850    Rune defender   tradeable=false canonical=8850              <=           
FILTERED        10499   Ava's accumulator       tradeable=false canonical=10499        <=           
FILTERED        12637   Saradomin halo  tradeable=false canonical=12637           <=           
FILTERED        12638   Zamorak halo    tradeable=false canonical=12638             <=           
FILTERED        12639   Guthix halo     tradeable=false canonical=12639              <=           
FILTERED        12791   Rune pouch      tradeable=false canonical=12791               <=           
FILTERED        12954   Dragon defender tradeable=false canonical=12954          <=           
FILTERED        20714   Tome of fire    tradeable=false canonical=20714             <=           
FILTERED        21297   Infernal cape   tradeable=false canonical=21297            <=           
FILTERED        21791   Imbued saradomin cape   tradeable=false canonical=21791    <=           
FILTERED        21793   Imbued guthix cape      tradeable=false canonical=21793       <=           
FILTERED        21795   Imbued zamorak cape     tradeable=false canonical=21795      <=           
FILTERED        24424   Volatile nightmare staff        tradeable=false canonical=24424 <=           
FILTERED        25258   Seers ring (i)  tradeable=false canonical=25258           <=           
FILTERED        25264   Berserker ring (i)      tradeable=false canonical=25264       <=           
FILTERED        25867   Bow of faerdhinen (c)   tradeable=false canonical=25867    <=           
FILTERED        25869   Bow of faerdhinen (c)   tradeable=false canonical=25869    <=           
FILTERED        25884   Bow of faerdhinen (c)   tradeable=false canonical=25884    <=           
FILTERED        25886   Bow of faerdhinen (c)   tradeable=false canonical=25886    <=           
FILTERED        25888   Bow of faerdhinen (c)   tradeable=false canonical=25888    <=           
FILTERED        25890   Bow of faerdhinen (c)   tradeable=false canonical=25890    <=           
FILTERED        25892   Bow of faerdhinen (c)   tradeable=false canonical=25892    <=           
FILTERED        25894   Bow of faerdhinen (c)   tradeable=false canonical=25894    <=           
FILTERED        25896   Bow of faerdhinen (c)   tradeable=false canonical=25896    <=           
FILTERED        26767   Seers ring (i)  tradeable=false canonical=26767           <=           
FILTERED        26770   Berserker ring (i)      tradeable=false canonical=26770       <=           
FILTERED        33021   Bow of faerdhinen (c)   tradeable=false canonical=33021    <=           
FILTERED        33758   Spear   tradeable=false canonical=33758                    <=
```

If an item was tradeable and used in LMS it prevented the untradable item from being found in search.