### PR TITLE
Extend the PluginMessage API

### DIFF
--- a/src/main/java/inventorysetups/InventorySetupsPersistentDataManager.java
+++ b/src/main/java/inventorysetups/InventorySetupsPersistentDataManager.java
@@ -138,6 +138,8 @@ public class InventorySetupsPersistentDataManager
 
 			// Setups were just persisted; notify integrating plugins.
 			plugin.broadcastSetupsChanged();
+			// Also notify of content edits to the still-active setup (slot/note/fuzzy changes, etc.).
+			plugin.broadcastActiveSetupChanged();
 		}
 
 		if (updateSections)

--- a/src/main/java/inventorysetups/InventorySetupsPlugin.java
+++ b/src/main/java/inventorysetups/InventorySetupsPlugin.java
@@ -2672,6 +2672,11 @@ public class InventorySetupsPlugin extends Plugin
 		pluginMessageHandler.broadcastSetupsChanged();
 	}
 
+	public void broadcastActiveSetupChanged()
+	{
+		pluginMessageHandler.broadcastActiveSetupChanged();
+	}
+
 	@Subscribe
 	public void onPluginMessage(final PluginMessage message)
 	{

--- a/src/main/java/inventorysetups/InventorySetupsPluginMessageHandler.java
+++ b/src/main/java/inventorysetups/InventorySetupsPluginMessageHandler.java
@@ -22,8 +22,11 @@ import java.util.Map;
 //
 // Supported messages are documented on the constants below. To track the available setups, subscribe
 // to PluginMessage and listen for "setups-changed" broadcasts, and post "get-setups" once on startup
-// (posting is synchronous, so the collection you pass is filled before post() returns). Payload values
-// are plain JDK types (String, int, Collection<String>) so they are visible across plugin classloaders.
+// (posting is synchronous, so the collection you pass is filled before post() returns). To track the
+// active setup (including live edits to it), listen for "active-setup-changed" broadcasts and post
+// "get-active-setup-contents" whenever you need its current contents. Payload values are plain JDK
+// types (String, int, boolean, Collection<Integer>/<String>) so they are visible across plugin
+// classloaders.
 @Slf4j
 public class InventorySetupsPluginMessageHandler
 {
@@ -40,9 +43,22 @@ public class InventorySetupsPluginMessageHandler
 	// in: clear the current setup (like worn items "Close current setup"). data["setup"] = name to clear
 	// only when it is the active setup; omit to clear whatever is active.
 	public static final String API_MSG_CLEAR = "clear";
+	// out: broadcast when the active setup changes - on opening, closing and editing
+	// of the setup that's still active (add/remove an item, toggle fuzzy, etc.)
+	// data["setup"] = the active setup's name; the key is absent when setup is closed.
+	public static final String API_MSG_ACTIVE_SETUP_CHANGED = "active-setup-changed";
+	// in: get the active setup's contents by slot, e.g. for a plugin that wants to mirror its layout elsewhere.
+	// Put mutable Collection<Integer> under "equipmentItemIds" (EquipmentInventorySlot order,
+	// size 14), "inventoryItemIds" (size 28), and "additionalItemIds" (no position semantics). Posting is synchronous.
+	// data["hasActiveSetup"] is set to false when no setup is active or the active setup has bank filtering disabled.
+	public static final String API_MSG_GET_ACTIVE_SETUP_CONTENTS = "get-active-setup-contents";
 	public static final String API_DATA_SETUPS = "setups";
 	public static final String API_DATA_SETUP = "setup";
 	public static final String API_DATA_VERSION = "version";
+	public static final String API_DATA_HAS_ACTIVE_SETUP = "hasActiveSetup";
+	public static final String API_DATA_EQUIPMENT_ITEM_IDS = "equipmentItemIds";
+	public static final String API_DATA_INVENTORY_ITEM_IDS = "inventoryItemIds";
+	public static final String API_DATA_ADDITIONAL_ITEM_IDS = "additionalItemIds";
 
 	private final InventorySetupsPlugin plugin;
 	private final ClientThread clientThread;
@@ -80,13 +96,26 @@ public class InventorySetupsPluginMessageHandler
 		});
 	}
 
+	// Broadcasts the active setup's name, or clears it. Called on selection change and on every content
+	// edit of the setup that's still active. Deliberately not deduped like broadcastSetupsChanged() -
+	// content edits don't change the name, but callers still need to know to re-read the contents.
+	public void broadcastActiveSetupChanged()
+	{
+		clientThread.invoke(() ->
+		{
+			final InventorySetup active = panel.getCurrentSelectedSetup();
+			final Map<String, Object> data = active == null ? Map.of() : Map.of(API_DATA_SETUP, active.getName());
+			eventBus.post(new PluginMessage(API_NAMESPACE, API_MSG_ACTIVE_SETUP_CHANGED, data));
+		});
+	}
+
 	public void handleMessage(final PluginMessage message)
 	{
 		if (!API_NAMESPACE.equals(message.getNamespace()))
 		{
 			return;
 		}
-		if (API_MSG_SETUPS_CHANGED.equals(message.getName()))
+		if (API_MSG_SETUPS_CHANGED.equals(message.getName()) || API_MSG_ACTIVE_SETUP_CHANGED.equals(message.getName()))
 		{
 			// Our own outgoing broadcast.
 			return;
@@ -107,6 +136,11 @@ public class InventorySetupsPluginMessageHandler
 			case API_MSG_CLEAR:
 			{
 				handleClear(message);
+				break;
+			}
+			case API_MSG_GET_ACTIVE_SETUP_CONTENTS:
+			{
+				handleGetActiveSetupContents(message);
 				break;
 			}
 			default:
@@ -186,6 +220,52 @@ public class InventorySetupsPluginMessageHandler
 				panel.returnToOverviewPanel(false);
 			}
 		});
+	}
+
+	private void handleGetActiveSetupContents(final PluginMessage message)
+	{
+		final Object equipmentObj = message.getData().getOrDefault(API_DATA_EQUIPMENT_ITEM_IDS, null);
+		final Object inventoryObj = message.getData().getOrDefault(API_DATA_INVENTORY_ITEM_IDS, null);
+		final Object additionalObj = message.getData().getOrDefault(API_DATA_ADDITIONAL_ITEM_IDS, null);
+		if (!(equipmentObj instanceof Collection) || !(inventoryObj instanceof Collection) || !(additionalObj instanceof Collection))
+		{
+			log.warn("Ignoring {} message without the expected mutable collections", API_MSG_GET_ACTIVE_SETUP_CONTENTS);
+			return;
+		}
+
+		clientThread.invoke(() ->
+		{
+			final InventorySetup setup = panel.getCurrentSelectedSetup();
+			final boolean hasActiveSetup = setup != null && setup.isFilterBank() && plugin.isFilteringAllowed();
+			message.getData().put(API_DATA_HAS_ACTIVE_SETUP, hasActiveSetup);
+			if (!hasActiveSetup)
+			{
+				return;
+			}
+
+			final Collection<Integer> equipmentItemIds = asIntegerCollection(equipmentObj);
+			final Collection<Integer> inventoryItemIds = asIntegerCollection(inventoryObj);
+			final Collection<Integer> additionalItemIds = asIntegerCollection(additionalObj);
+
+			for (final InventorySetupsItem item : setup.getEquipment())
+			{
+				equipmentItemIds.add(InventorySetupsItem.itemIsDummy(item) ? -1 : item.getId());
+			}
+			for (final InventorySetupsItem item : setup.getInventory())
+			{
+				inventoryItemIds.add(InventorySetupsItem.itemIsDummy(item) ? -1 : item.getId());
+			}
+			for (final InventorySetupsItem item : setup.getAdditionalFilteredItems().values())
+			{
+				additionalItemIds.add(item.getId());
+			}
+		});
+	}
+
+	@SuppressWarnings("unchecked")
+	private static Collection<Integer> asIntegerCollection(final Object obj)
+	{
+		return (Collection<Integer>) obj;
 	}
 
 	private List<String> buildSetupNames()

--- a/src/main/java/inventorysetups/ui/InventorySetupsPluginPanel.java
+++ b/src/main/java/inventorysetups/ui/InventorySetupsPluginPanel.java
@@ -754,6 +754,7 @@ public class InventorySetupsPluginPanel extends PluginPanel
 	{
 		overviewPanelScrollPosition = contentWrapperPane.getVerticalScrollBar().getValue();
 		currentSelectedSetup = inventorySetup;
+		plugin.broadcastActiveSetupChanged();
 		inventoryPanel.updatePanelWithSetupInformation(inventorySetup);
 		runePouchPanel.updatePanelWithSetupInformation(inventorySetup);
 		boltPouchPanel.updatePanelWithSetupInformation(inventorySetup);
@@ -867,6 +868,7 @@ public class InventorySetupsPluginPanel extends PluginPanel
 		}
 
 		currentSelectedSetup = null;
+		plugin.broadcastActiveSetupChanged();
 
 		plugin.resetBankSearch();
 


### PR DESCRIPTION
#### Add `active-setup-changed` broadcast and `get-active-setup-contents` query to the PluginMessage API

### What
Extends the existing `PluginMessage` integration API (`InventorySetupsPluginMessageHandler`) with two small, purely additive messages:

- **`active-setup-changed`** (out, broadcast) — fires whenever the active setup changes, including edits to the contents of the setup that's still active (not just selection changes). Payload: `data["setup"]` = the active setup's name, or the key is absent when no setup is active.
- **`get-active-setup-contents`** (in, synchronous query) — Fills:
  - `data["hasActiveSetup"]` (`Boolean`) — false when no setup is selected or bank filtering is disabled for it.
  - `data["equipmentItemIds"]` / `data["inventoryItemIds"]` (`List<Integer>`) — the setup's equipment/inventory items by slot, `-1` for empty slots.
  - `data["additionalItemIds"]` (`Collection<Integer>`) — the setup's additional filtered items.

### Why
These additions would allow my upcoming plugin to mirror Inventory Setups setup's contents into the Group Ironman shared bank (filtering + a best-effort layout). The existing API exposes the list of setup *names* but nothing about which one is active or what's in it, so there was no way to do this without polling internals. These two messages close that gap the same way `get-setups`/`setups-changed` already do for the setup list.

### Changes
- `InventorySetupsPluginMessageHandler.java` — new constants/handlers for both messages, doc comment updated.
- `InventorySetupsPlugin.java` — `broadcastActiveSetupChanged()` delegate, next to the existing `broadcastSetupsChanged()`.
- `InventorySetupsPluginPanel.java` — calls the new broadcast from `setCurrentInventorySetup()`/`returnToOverviewPanel()`.
- `InventorySetupsPersistentDataManager.java` — also calls it from `updateConfig()`, so edits to the still-active setup broadcast too, not just selection changes.

No existing behavior changes; both messages are additive.
